### PR TITLE
nvmf: add subsystem's namespace pause/resume rpc

### DIFF
--- a/doc/jsonrpc.md
+++ b/doc/jsonrpc.md
@@ -7793,8 +7793,8 @@ Example response:
       "serial_number": "abcdef",
       "model_number": "ghijklmnop",
       "namespaces": [
-        {"nsid": 1, "name": "Malloc2"},
-        {"nsid": 2, "name": "Nvme0n1"}
+        {"nsid": 1, "name": "Malloc2", "paused": false},
+        {"nsid": 2, "name": "Nvme0n1", "paused": true}
       ]
     }
   ]
@@ -12060,4 +12060,80 @@ Example response:
     ]
   }
 ]
+~~~
+
+### nvmf_pause_namespace method {#rpc_nvmf_pause_namespace}
+
+Pause I/O over a NVMe-oF subsystem's namespace.
+
+#### Parameters
+
+Parameter              | Optional | Type        | Description
+---------------------- | -------- | ----------- | -----------
+nqn                    | Required | string      | Subsystem NQN.
+nsid                   | Required | number      | Namespace ID
+tgt_name               | Optional | string      | Parent NVMe-oF target name.
+
+#### Example
+
+Example request:
+
+~~~json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "nvmf_pause_namespace",
+  "params": {
+    "nqn": "nqn.2023-03.io.spdk:cnode1",
+    "nsid": 1
+  }
+}
+~~~
+
+Example response:
+
+~~~json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": true
+}
+~~~
+
+### nvmf_resume_namespace method {#rpc_nvmf_resume_namespace}
+
+Resume I/O over a NVMe-oF subsystem's namespace.
+
+#### Parameters
+
+Parameter              | Optional | Type        | Description
+---------------------- | -------- | ----------- | -----------
+nqn                    | Required | string      | Subsystem NQN.
+nsid                   | Required | number      | Namespace ID
+tgt_name               | Optional | string      | Parent NVMe-oF target name.
+
+#### Example
+
+Example request:
+
+~~~json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "nvmf_resume_namespace",
+  "params": {
+    "nqn": "nqn.2023-03.io.spdk:cnode1",
+    "nsid": 1
+  }
+}
+~~~
+
+Example response:
+
+~~~json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": true
+}
 ~~~

--- a/include/spdk/nvmf.h
+++ b/include/spdk/nvmf.h
@@ -903,6 +903,55 @@ void spdk_nvmf_ns_get_opts(const struct spdk_nvmf_ns *ns, struct spdk_nvmf_ns_op
 			   size_t opts_size);
 
 /**
+ * Pause I/O over a NVMe-oF subsystem's namespace.
+ *
+ * In a paused state, all incoming I/O over that namespace are queued until the
+ * namespace or the entire subsystem is resumed.
+ * The subsystem must be in active state.
+ *
+ * \param subsystem The NVMe-oF subsystem.
+ * \param nsid ID of the namespace to pause.
+ * \param cb_fn A function that will be called once the subsystem has changed state.
+ * \param cb_arg Argument passed to cb_fn.
+ *
+ * \return 0 on success, or negated errno on failure. The callback provided will only
+ * be called on success.
+ */
+int spdk_nvmf_ns_pause(struct spdk_nvmf_subsystem *subsystem,
+		       uint32_t nsid,
+		       spdk_nvmf_subsystem_state_change_done cb_fn,
+		       void *cb_arg);
+
+/**
+ * Resume I/O over a NVMe-oF subsystem's namespace.
+ *
+ * All queued I/O over that namespace are released and executed.
+ * The subsystem must be in active state.
+ *
+ * \param subsystem The NVMe-oF subsystem.
+ * \param nsid ID of the namespace to resume.
+ * \param cb_fn A function that will be called once the subsystem has changed state.
+ * \param cb_arg Argument passed to cb_fn.
+ *
+ * \return 0 on success, or negated errno on failure. The callback provided will only
+ * be called on success.
+ */
+int spdk_nvmf_ns_resume(struct spdk_nvmf_subsystem *subsystem,
+			uint32_t nsid,
+			spdk_nvmf_subsystem_state_change_done cb_fn,
+			void *cb_arg);
+
+/**
+ * Get a namespace's paused status.
+ *
+ * \param ns Namespace to query.
+ *
+ * \return true if namespace is paused, false otherwise.
+ */
+bool spdk_nvmf_ns_is_paused(const struct spdk_nvmf_subsystem *subsystem,
+			    uint32_t nsid);
+
+/**
  * Get the serial number of the specified subsystem.
  *
  * \param subsystem Subsystem to query.

--- a/lib/nvmf/nvmf_rpc.c
+++ b/lib/nvmf/nvmf_rpc.c
@@ -270,6 +270,9 @@ dump_nvmf_subsystem(struct spdk_json_write_ctx *w, struct spdk_nvmf_subsystem *s
 				spdk_json_write_named_uint32(w, "anagrpid", ns_opts.anagrpid);
 			}
 
+			spdk_json_write_named_bool(w, "paused",
+						   spdk_nvmf_ns_is_paused(subsystem, spdk_nvmf_ns_get_id(ns)));
+
 			spdk_json_write_object_end(w);
 		}
 		spdk_json_write_array_end(w);
@@ -2500,4 +2503,140 @@ rpc_nvmf_subsystem_get_listeners(struct spdk_jsonrpc_request *request,
 	_rpc_nvmf_subsystem_query(request, params, rpc_nvmf_get_listeners_paused);
 }
 SPDK_RPC_REGISTER("nvmf_subsystem_get_listeners", rpc_nvmf_subsystem_get_listeners,
+		  SPDK_RPC_RUNTIME);
+
+struct rpc_pause_resume_namespace {
+	char		*nqn;
+	char		*tgt_name;
+	uint32_t	nsid;
+};
+
+static void
+free_rpc_pause_resume_namespace(struct rpc_pause_resume_namespace *r)
+{
+	free(r->nqn);
+	free(r->tgt_name);
+}
+
+static void
+rpc_nvmf_namespace_pause_resume_done(struct spdk_nvmf_subsystem *subsystem,
+				     void *cb_arg, int status)
+{
+	struct spdk_jsonrpc_request *request = cb_arg;
+
+	if (status) {
+		spdk_jsonrpc_send_bool_response(request, false);
+	} else {
+		spdk_jsonrpc_send_bool_response(request, true);
+	}
+}
+
+static const struct spdk_json_object_decoder rpc_pause_resume_namespace_decoders[] = {
+	{"nqn", offsetof(struct rpc_pause_resume_namespace, nqn), spdk_json_decode_string},
+	{"nsid", offsetof(struct rpc_pause_resume_namespace, nsid), spdk_json_decode_uint32},
+	{"tgt_name", offsetof(struct rpc_pause_resume_namespace, tgt_name), spdk_json_decode_string, true},
+};
+
+static void
+rpc_nvmf_pause_namespace(struct spdk_jsonrpc_request *request,
+			 const struct spdk_json_val *params)
+{
+	struct rpc_pause_resume_namespace req = { 0 };
+	struct spdk_nvmf_subsystem *subsystem;
+	struct spdk_nvmf_tgt *tgt;
+	int rc;
+
+	if (spdk_json_decode_object(params, rpc_pause_resume_namespace_decoders,
+				    SPDK_COUNTOF(rpc_pause_resume_namespace_decoders),
+				    &req)) {
+		SPDK_ERRLOG("spdk_json_decode_object failed\n");
+		goto invalid;
+	}
+
+	if (req.nqn == NULL) {
+		SPDK_ERRLOG("missing name param\n");
+		goto invalid;
+	}
+
+	tgt = spdk_nvmf_get_tgt(req.tgt_name);
+	if (!tgt) {
+		SPDK_ERRLOG("Unable to find a target object.\n");
+		spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_INTERNAL_ERROR,
+						 "Unable to find a target");
+		goto invalid_custom_response;
+	}
+
+	subsystem = spdk_nvmf_tgt_find_subsystem(tgt, req.nqn);
+	if (!subsystem) {
+		SPDK_ERRLOG("Unable to find subsystem with NQN %s\n", req.nqn);
+		goto invalid;
+	}
+
+	rc = spdk_nvmf_ns_pause(subsystem, req.nsid, rpc_nvmf_namespace_pause_resume_done, request);
+	if (rc != 0) {
+		SPDK_ERRLOG("Pausing namespace %u of subsystem with NQN %s failed\n", req.nsid, req.nqn);
+		spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_INTERNAL_ERROR, "Internal error");
+	}
+
+	free_rpc_pause_resume_namespace(&req);
+
+	return;
+
+invalid:
+	spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_INVALID_PARAMS, "Invalid parameters");
+invalid_custom_response:
+	free_rpc_pause_resume_namespace(&req);
+}
+SPDK_RPC_REGISTER("nvmf_pause_namespace", rpc_nvmf_pause_namespace,
+		  SPDK_RPC_RUNTIME);
+
+static void
+rpc_nvmf_resume_namespace(struct spdk_jsonrpc_request *request,
+			  const struct spdk_json_val *params)
+{
+	struct rpc_pause_resume_namespace req = { 0 };
+	struct spdk_nvmf_subsystem *subsystem;
+	struct spdk_nvmf_tgt *tgt;
+
+	if (spdk_json_decode_object(params, rpc_pause_resume_namespace_decoders,
+				    SPDK_COUNTOF(rpc_pause_resume_namespace_decoders),
+				    &req)) {
+		SPDK_ERRLOG("spdk_json_decode_object failed\n");
+		goto invalid;
+	}
+
+	if (req.nqn == NULL) {
+		SPDK_ERRLOG("missing name param\n");
+		goto invalid;
+	}
+
+	tgt = spdk_nvmf_get_tgt(req.tgt_name);
+	if (!tgt) {
+		SPDK_ERRLOG("Unable to find a target object.\n");
+		spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_INTERNAL_ERROR,
+						 "Unable to find a target");
+		goto invalid_custom_response;
+	}
+
+	subsystem = spdk_nvmf_tgt_find_subsystem(tgt, req.nqn);
+	if (!subsystem) {
+		SPDK_ERRLOG("Unable to find subsystem with NQN %s\n", req.nqn);
+		goto invalid;
+	}
+
+	if (spdk_nvmf_ns_resume(subsystem, req.nsid, rpc_nvmf_namespace_pause_resume_done, request)) {
+		SPDK_ERRLOG("Resuming namespace %u of subsystem with NQN %s failed\n", req.nsid, req.nqn);
+		spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_INTERNAL_ERROR, "Internal error");
+	}
+
+	free_rpc_pause_resume_namespace(&req);
+
+	return;
+
+invalid:
+	spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_INVALID_PARAMS, "Invalid parameters");
+invalid_custom_response:
+	free_rpc_pause_resume_namespace(&req);
+}
+SPDK_RPC_REGISTER("nvmf_resume_namespace", rpc_nvmf_resume_namespace,
 		  SPDK_RPC_RUNTIME);

--- a/python/spdk/rpc/nvmf.py
+++ b/python/spdk/rpc/nvmf.py
@@ -594,3 +594,43 @@ def nvmf_set_crdt(client, crdt1=None, crdt2=None, crdt3=None):
         params['crdt3'] = crdt3
 
     return client.call('nvmf_set_crdt', params)
+
+
+def nvmf_pause_namespace(client, nqn, nsid, tgt_name=None):
+    """Pause I/O over a NVMe-oF subsystem's namespace.
+
+    Args:
+        nqn: Subsystem NQN.
+        nsid: Namespace ID
+        tgt_name: name of the parent NVMe-oF target (optional).
+
+    Returns:
+        True or False
+    """
+    params = {'nqn': nqn,
+              'nsid': nsid}
+
+    if tgt_name:
+        params['tgt_name'] = tgt_name
+
+    return client.call('nvmf_pause_namespace', params)
+
+
+def nvmf_resume_namespace(client, nqn, nsid, tgt_name=None):
+    """Resume I/O over a NVMe-oF subsystem's namespace.
+
+    Args:
+        nqn: Subsystem NQN.
+        nsid: Namespace ID
+        tgt_name: name of the parent NVMe-oF target (optional).
+
+    Returns:
+        True or False
+    """
+    params = {'nqn': nqn,
+              'nsid': nsid}
+
+    if tgt_name:
+        params['tgt_name'] = tgt_name
+
+    return client.call('nvmf_resume_namespace', params)

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -2628,6 +2628,34 @@ Format: 'user:u1 secret:s1 muser:mu1 msecret:ms1,user:u2 secret:s2 muser:mu2 mse
     p.add_argument('-t3', '--crdt3', help='Command Retry Delay Time 3, in units of 100 milliseconds', type=int)
     p.set_defaults(func=nvmf_set_crdt)
 
+    def nvmf_pause_namespace(args):
+        rpc.nvmf.nvmf_pause_namespace(args.client,
+                                      nqn=args.subsystem_nqn,
+                                      nsid=args.namespace_id,
+                                      tgt_name=args.tgt_name)
+
+    p = subparsers.add_parser('nvmf_pause_namespace', help='Pause I/O over a NVMe-oF subsystem\'s namespace')
+    p.add_argument('subsystem_nqn',
+                   help='The nqn of namespace\'s parent subsystem. Example: nqn.2023-03.io.spdk:cnode1.',
+                   type=str)
+    p.add_argument('namespace_id', help='ID of the namespace to be paused. Start from 1.', type=int)
+    p.add_argument('-t', '--tgt-name', help='The name of the parent NVMe-oF target (optional)', type=str)
+    p.set_defaults(func=nvmf_pause_namespace)
+
+    def nvmf_resume_namespace(args):
+        rpc.nvmf.nvmf_resume_namespace(args.client,
+                                       nqn=args.subsystem_nqn,
+                                       nsid=args.namespace_id,
+                                       tgt_name=args.tgt_name)
+
+    p = subparsers.add_parser('nvmf_resume_namespace', help='Resume I/O over a NVMe-oF subsystem\'s namespace')
+    p.add_argument('subsystem_nqn',
+                   help='The nqn of namespace\'s parent subsystem. Example: nqn.2023-03.io.spdk:cnode1.',
+                   type=str)
+    p.add_argument('namespace_id', help='ID of the namespace to be resumed. Start from 1.', type=int)
+    p.add_argument('-t', '--tgt-name', help='The name of the parent NVMe-oF target (optional)', type=str)
+    p.set_defaults(func=nvmf_resume_namespace)
+
     # subsystem
     def framework_get_subsystems(args):
         print_dict(rpc.subsystem.framework_get_subsystems(args.client))

--- a/test/unit/lib/nvmf/subsystem.c/subsystem_ut.c
+++ b/test/unit/lib/nvmf/subsystem.c/subsystem_ut.c
@@ -162,6 +162,22 @@ nvmf_poll_group_resume_subsystem(struct spdk_nvmf_poll_group *group,
 {
 }
 
+void
+nvmf_poll_group_pause_ns(struct spdk_nvmf_poll_group *group,
+			 struct spdk_nvmf_subsystem *subsystem,
+			 uint32_t nsid,
+			 spdk_nvmf_poll_group_mod_done cb_fn, void *cb_arg)
+{
+}
+
+void
+nvmf_poll_group_resume_ns(struct spdk_nvmf_poll_group *group,
+			  struct spdk_nvmf_subsystem *subsystem,
+			  uint32_t nsid,
+			  spdk_nvmf_poll_group_mod_done cb_fn, void *cb_arg)
+{
+}
+
 int
 spdk_nvme_transport_id_parse_trtype(enum spdk_nvme_transport_type *trtype, const char *str)
 {
@@ -1763,6 +1779,99 @@ test_nvmf_subsystem_state_change(void)
 	free(tgt.subsystems);
 }
 
+static void
+test_nvmf_ns_state_change(void)
+{
+	struct spdk_nvmf_tgt tgt = {};
+	struct spdk_nvmf_subsystem *subsystem;
+	struct spdk_nvmf_ns_opts ns_opts;
+	uint32_t nsid;
+	int rc;
+
+	/* Create subsystem */
+	tgt.max_subsystems = 1024;
+	tgt.subsystems = calloc(tgt.max_subsystems, sizeof(struct spdk_nvmf_subsystem *));
+	SPDK_CU_ASSERT_FATAL(tgt.subsystems != NULL);
+
+	subsystem = spdk_nvmf_subsystem_create(&tgt, "nqn.2023-03.io.spdk:subsystem1",
+					       SPDK_NVMF_SUBTYPE_NVME, 0);
+	SPDK_CU_ASSERT_FATAL(subsystem != NULL);
+
+	spdk_io_device_register(&tgt,
+				nvmf_tgt_create_poll_group,
+				nvmf_tgt_destroy_poll_group,
+				sizeof(struct spdk_nvmf_poll_group),
+				NULL);
+
+	/* Add namespace to subsystem and start subsystem */
+	spdk_nvmf_ns_opts_get_defaults(&ns_opts, sizeof(ns_opts));
+	nsid = spdk_nvmf_subsystem_add_ns_ext(subsystem, "bdev2", &ns_opts, sizeof(ns_opts), NULL);
+	CU_ASSERT(nsid == 1);
+	SPDK_CU_ASSERT_FATAL(subsystem->ns[nsid - 1] != NULL);
+	CU_ASSERT(subsystem->ns[nsid - 1]->bdev == &g_bdevs[1]);
+
+	rc = spdk_nvmf_subsystem_start(subsystem, NULL, NULL);
+	CU_ASSERT(rc == 0);
+	poll_threads();
+	CU_ASSERT(subsystem->state == SPDK_NVMF_SUBSYSTEM_ACTIVE);
+
+	/* Successfully namespace pause/resume */
+	rc = spdk_nvmf_ns_pause(subsystem, 1, NULL, NULL);
+	CU_ASSERT(rc == 0);
+	poll_threads();
+
+	rc = spdk_nvmf_ns_resume(subsystem, 1, NULL, NULL);
+	CU_ASSERT(rc == 0);
+	poll_threads();
+
+	/* Bad namespace pause due to paused subsystem */
+	rc = spdk_nvmf_subsystem_pause(subsystem, SPDK_NVME_GLOBAL_NS_TAG, NULL, NULL);
+	CU_ASSERT(rc == 0);
+	poll_threads();
+	CU_ASSERT(subsystem->state == SPDK_NVMF_SUBSYSTEM_PAUSED);
+
+	rc = spdk_nvmf_ns_pause(subsystem, 1, NULL, NULL);
+	CU_ASSERT(rc == -EPERM);
+
+	rc = spdk_nvmf_subsystem_resume(subsystem, NULL, NULL);
+	CU_ASSERT(rc == 0);
+	poll_threads();
+	CU_ASSERT(subsystem->state == SPDK_NVMF_SUBSYSTEM_ACTIVE);
+
+	/* Bad namespace resume due to paused subsystem */
+	rc = spdk_nvmf_ns_pause(subsystem, 1, NULL, NULL);
+	CU_ASSERT(rc == 0);
+	poll_threads();
+
+	rc = spdk_nvmf_subsystem_pause(subsystem, SPDK_NVME_GLOBAL_NS_TAG, NULL, NULL);
+	CU_ASSERT(rc == 0);
+	poll_threads();
+	CU_ASSERT(subsystem->state == SPDK_NVMF_SUBSYSTEM_PAUSED);
+
+	rc = spdk_nvmf_ns_resume(subsystem, 1, NULL, NULL);
+	CU_ASSERT(rc == -EPERM);
+
+	rc = spdk_nvmf_subsystem_resume(subsystem, NULL, NULL);
+	CU_ASSERT(rc == 0);
+	poll_threads();
+	CU_ASSERT(subsystem->state == SPDK_NVMF_SUBSYSTEM_ACTIVE);
+
+	/* Stop subsystem */
+	rc = spdk_nvmf_subsystem_stop(subsystem, NULL, NULL);
+	CU_ASSERT(rc == 0);
+	poll_threads();
+	CU_ASSERT(subsystem->state == SPDK_NVMF_SUBSYSTEM_INACTIVE);
+
+	/* Destroy subsystem */
+	rc = spdk_nvmf_subsystem_destroy(subsystem, NULL, NULL);
+	CU_ASSERT(rc == 0);
+
+	spdk_io_device_unregister(&tgt, NULL);
+	poll_threads();
+
+	free(tgt.subsystems);
+}
+
 int
 main(int argc, char **argv)
 {
@@ -1795,6 +1904,7 @@ main(int argc, char **argv)
 	CU_ADD_TEST(suite, test_nvmf_valid_nqn);
 	CU_ADD_TEST(suite, test_nvmf_ns_reservation_restore);
 	CU_ADD_TEST(suite, test_nvmf_subsystem_state_change);
+	CU_ADD_TEST(suite, test_nvmf_ns_state_change);
 
 	allocate_threads(1);
 	set_thread(0);


### PR DESCRIPTION
I/O over the selected subsystem's namespace can be paused and resumed. The subsystem must be in active state.
Added a flag to retriew ns paused status in nvmf_get_subsystems rpc