### PR TITLE
lvol/blob: get shallow copy status of ended ops

### DIFF
--- a/doc/jsonrpc.md
+++ b/doc/jsonrpc.md
@@ -10003,6 +10003,7 @@ Example response:
 
 Make a shallow copy of lvol over a given bdev. Only cluster allocated to the lvol will be written on the bdev.
 Must have:
+
 * lvol read only
 * lvol size smaller than bdev size
 * lvstore block size a multiple of bdev size
@@ -10046,8 +10047,8 @@ Get shallow copy status
 
 #### Result
 
-This RPC reports if a shallow copy is still in progress and operation's advance state in the format
-_number_of_copied_clusters/total_clusters_to_copy_
+This RPC reports the state of a shallow copy operation, in case of error a description, and
+operation's advance state in the format _number_of_copied_clusters/total_clusters_to_copy_.
 
 #### Parameters
 
@@ -10077,8 +10078,8 @@ Example response:
   "jsonrpc": "2.0",
   "id": 1,
   "result": {
-    "in_progress": true,
-    "status": "2/4"
+    "state": "in progress",
+    "progress": "2/4"
   }
 }
 ~~~

--- a/include/spdk/blob.h
+++ b/include/spdk/blob.h
@@ -518,26 +518,38 @@ uint64_t spdk_blob_get_next_unallocated_io_unit(struct spdk_blob *blob, uint64_t
 /**
  * Get the number of copied clusters of a shallow copy operation
 
- * If a shallow copy of the blob is in progress, this functions returns the number of already
- * copied clusters.
+ * If a shallow copy of the blob is in progress or it is ended, this function returns
+ * the number of copied clusters.
  *
  * \param blob Blob struct to query.
  *
- * \return cluster index or UINT64_MAX if no shallow copy is in progress
+ * \return number of copied clusters.
  */
 uint64_t spdk_blob_get_shallow_copy_copied_clusters(struct spdk_blob *blob);
 
 /**
  * Get the total number of clusters to be copied in a shallow copy operation
 
- * If a shallow copy of the blob is in progress, this functions returns the total number
- * of cluster involved in the operation.
+ * If a shallow copy of the blob is in progress or it is ended, this function returns
+ * the total number of clusters to be copied.
  *
  * \param blob Blob struct to query.
  *
- * \return total number, 0 if no shallow copy is in progress
+ * \return total number of clusters.
  */
 uint64_t spdk_blob_get_shallow_copy_total_clusters(struct spdk_blob *blob);
+
+/**
+ * Get the result of last shallow copy operation
+
+ * If a shallow copy of the blob is in progress or it is ended, this function returns
+ * the result of the operation.
+ *
+ * \param blob Blob struct to query.
+ *
+ * \return 0 on success, negative errno on failure.
+ */
+int spdk_blob_get_shallow_copy_result(struct spdk_blob *blob);
 
 struct spdk_blob_xattr_opts {
 	/* Number of attributes */

--- a/lib/blob/blobstore.h
+++ b/lib/blob/blobstore.h
@@ -153,6 +153,7 @@ struct spdk_blob {
 		struct {
 			uint64_t num_clusters_to_copy;
 			uint64_t copied_clusters_number;
+			int bserrno;
 		} shallow_copy;
 	} u;
 };

--- a/module/bdev/lvol/vbdev_lvol_rpc.c
+++ b/module/bdev/lvol/vbdev_lvol_rpc.c
@@ -1447,7 +1447,8 @@ rpc_bdev_lvol_shallow_copy_status(struct spdk_jsonrpc_request *request,
 	struct spdk_bdev *src_lvol_bdev;
 	struct spdk_lvol *src_lvol;
 	struct spdk_json_write_ctx *w;
-	uint64_t cluster_index, total_clusters;
+	uint64_t copied_clusters, total_clusters;
+	int result;
 
 	SPDK_INFOLOG(lvol_rpc, "Shallow copy status\n");
 
@@ -1474,16 +1475,26 @@ rpc_bdev_lvol_shallow_copy_status(struct spdk_jsonrpc_request *request,
 		goto cleanup;
 	}
 
-	cluster_index = spdk_blob_get_shallow_copy_copied_clusters(src_lvol->blob);
+	copied_clusters = spdk_blob_get_shallow_copy_copied_clusters(src_lvol->blob);
 	total_clusters = spdk_blob_get_shallow_copy_total_clusters(src_lvol->blob);
+	result = spdk_blob_get_shallow_copy_result(src_lvol->blob);
 
 	w = spdk_jsonrpc_begin_result(request);
 
 	spdk_json_write_object_begin(w);
-	spdk_json_write_named_bool(w, "in_progress", total_clusters > 0);
-	if (total_clusters > 0) {
-		spdk_json_write_named_string_fmt(w, "status", "%lu/%lu", cluster_index, total_clusters);
+
+	spdk_json_write_named_string_fmt(w, "progress", "%lu/%lu", copied_clusters, total_clusters);
+	if (result > 0) {
+		spdk_json_write_named_string(w, "state", "none");
+	} else if (copied_clusters < total_clusters && result == 0) {
+		spdk_json_write_named_string(w, "state", "in progress");
+	} else if (copied_clusters == total_clusters && result == 0) {
+		spdk_json_write_named_string(w, "state", "complete");
+	} else {
+		spdk_json_write_named_string(w, "state", "error");
+		spdk_json_write_named_string(w, "error", spdk_strerror(-result));
 	}
+
 	spdk_json_write_object_end(w);
 
 	spdk_jsonrpc_end_result(request, w);


### PR DESCRIPTION
Shallow copy status RPC now returns info of ongoing and even of ended operations.