### PR TITLE
Raid1 rw mode

### DIFF
--- a/doc/jsonrpc.md
+++ b/doc/jsonrpc.md
@@ -10295,6 +10295,46 @@ Example response:
 }
 ~~~
 
+### bdev_raid_set_base_bdev_mode {#rpc_bdev_raid_set_base_bdev_mode}
+
+Set the read and write mode of a base bdev. Mode should be one
+of 'rw', 'ro' or 'wo'. 'rw' means read and write enabled, 'ro' read
+only and 'wo' write only.
+All raid levels support 'rw', which is the default. Raid1 supports also 'wo'.
+
+#### Parameters
+
+Name                    | Optional | Type        | Description
+----------------------- | -------- | ----------- | -----------
+name                    | Required | string      | Base bdev name in RAID
+mode                    | Required | string      | read/write mode
+
+#### Example
+
+Example request:
+
+~~~json
+{
+  "jsonrpc": "2.0",
+  "method": "bdev_raid_set_base_bdev_mode",
+  "id": 1,
+  "params": {
+    "name": "Raid1",
+    "mode": "wo",
+  }
+}
+~~~
+
+Example response:
+
+~~~json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": true
+}
+~~~
+
 ## SPLIT
 
 ### bdev_split_create {#rpc_bdev_split_create}

--- a/doc/jsonrpc.md
+++ b/doc/jsonrpc.md
@@ -10335,6 +10335,48 @@ Example response:
 }
 ~~~
 
+### bdev_raid_add_base_bdev {#rpc_bdev_raid_add_base_bdev}
+
+Add a base bdev to an existing raid bdev.
+Optionally a read/write mode for the base bdev can be passed.
+Modes can be handled with `bdev_raid_set_base_bdev_mode`.
+The default mode is `"rw"`, raid1 supports also `"wo"`.
+
+#### Parameters
+
+Name                    | Optional | Type        | Description
+----------------------- | -------- | ----------- | -----------
+raid_name               | Required | string      | Raid bdev name
+base_name               | Required | string      | Base bdev name
+mode                    | Optional | string      | read/write mode
+
+#### Example
+
+Example request:
+
+~~~json
+{
+  "jsonrpc": "2.0",
+  "method": "bdev_raid_set_base_bdev_mode",
+  "id": 1,
+  "params": {
+    "raid_name": "Raid1",
+    "base_name": "Nvme1n1",
+    "mode": "wo",
+  }
+}
+~~~
+
+Example response:
+
+~~~json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": true
+}
+~~~
+
 ## SPLIT
 
 ### bdev_split_create {#rpc_bdev_split_create}

--- a/module/bdev/raid/bdev_raid.c
+++ b/module/bdev/raid/bdev_raid.c
@@ -1432,8 +1432,15 @@ raid_bdev_configure(struct raid_bdev *raid_bdev)
 	struct raid_base_bdev_info *base_info;
 	int rc = 0;
 
-	assert(raid_bdev->state == RAID_BDEV_STATE_CONFIGURING);
 	assert(raid_bdev->num_base_bdevs_discovered == raid_bdev->num_base_bdevs_operational);
+
+	/*
+	 * Check if raid is already configured, it is true in the case we are adding new base
+	 * bdevs to an existing and started raid
+	 */
+	if (raid_bdev->state == RAID_BDEV_STATE_ONLINE) {
+		return 0;
+	}
 
 	RAID_FOR_EACH_BASE_BDEV(raid_bdev, base_info) {
 		if (base_info->bdev == NULL) {
@@ -1756,6 +1763,7 @@ raid_bdev_remove_base_bdev_write_sb_cb(bool success, struct raid_bdev *raid_bdev
 		SPDK_ERRLOG("Failed to write raid bdev '%s' superblock\n", raid_bdev->bdev.name);
 	}
 
+	raid_bdev->base_bdev_updating = false;
 	raid_bdev_resume(raid_bdev, NULL, NULL);
 }
 
@@ -1783,14 +1791,14 @@ raid_bdev_remove_base_bdev_done(struct spdk_io_channel_iter *i, int status)
 
 		assert(i < sb->base_bdevs_size);
 
-		/* TODO: distinguish between failure and intentional removal */
-		sb_base_bdev->state = RAID_SB_BASE_BDEV_FAILED;
+		sb_base_bdev->state = RAID_SB_BASE_BDEV_REMOVED;
 
 		rc = raid_bdev_write_superblock(raid_bdev, raid_bdev_remove_base_bdev_write_sb_cb, NULL);
 		if (rc != 0) {
 			raid_bdev_remove_base_bdev_write_sb_cb(false, raid_bdev, NULL);
 		}
 	} else {
+		raid_bdev->base_bdev_updating = false;
 		raid_bdev_resume(raid_bdev, NULL, NULL);
 	}
 }
@@ -1842,6 +1850,12 @@ raid_bdev_remove_base_bdev(struct spdk_bdev *base_bdev)
 		return 0;
 	}
 
+	if (raid_bdev->base_bdev_updating == true) {
+		SPDK_ERRLOG("Another operation is in progress.\n");
+		return -EBUSY;
+	}
+
+	raid_bdev->base_bdev_updating = true;
 	assert(base_info->desc);
 	base_info->remove_scheduled = true;
 
@@ -1855,8 +1869,10 @@ raid_bdev_remove_base_bdev(struct spdk_bdev *base_bdev)
 			/* There is no base bdev for this raid, so free the raid device. */
 			raid_bdev_cleanup_and_free(raid_bdev);
 		}
+		raid_bdev->base_bdev_updating = false;
 	} else if (raid_bdev->num_base_bdevs_operational-- == raid_bdev->min_base_bdevs_operational) {
 		raid_bdev_deconfigure(raid_bdev, NULL, NULL);
+		raid_bdev->base_bdev_updating = false;
 	} else {
 		return raid_bdev_suspend(raid_bdev, raid_bdev_remove_base_bdev_on_suspended, base_info);
 	}
@@ -1895,6 +1911,7 @@ raid_bdev_set_base_bdev_mode_done(struct spdk_io_channel_iter *i, int status)
 	struct raid_base_bdev_info *base_info = ctx->base_info;
 	struct raid_bdev *raid_bdev = base_info->raid_bdev;
 
+	raid_bdev->base_bdev_updating = false;
 	raid_bdev_resume(raid_bdev, ctx->cb_fn, ctx->cb_arg);
 	free(ctx);
 }
@@ -1958,7 +1975,8 @@ raid_bdev_set_base_bdev_mode(struct spdk_bdev *base_bdev, enum raid_base_bdev_mo
 
 	assert(spdk_get_thread() == spdk_thread_get_app_thread());
 
-	if (base_info->remove_scheduled) {
+	if (raid_bdev->base_bdev_updating == true) {
+		SPDK_ERRLOG("Another operation is in progress.\n");
 		return -EBUSY;
 	}
 
@@ -1970,11 +1988,312 @@ raid_bdev_set_base_bdev_mode(struct spdk_bdev *base_bdev, enum raid_base_bdev_mo
 		return -ENOMEM;
 	}
 
+	raid_bdev->base_bdev_updating = true;
+
 	ctx->base_info = base_info;
 	ctx->cb_fn = cb_fn;
 	ctx->cb_arg = cb_arg;
 
 	return raid_bdev_suspend(raid_bdev, raid_bdev_set_base_bdev_mode_on_suspended, ctx);
+}
+
+struct raid_bdev_add_base_bdev_ctx {
+	struct raid_bdev *raid_bdev;
+	char *base_bdev_name;
+	enum raid_base_bdev_mode mode;
+	int status;
+	uint8_t slot;
+	raid_bdev_destruct_cb cb_fn;
+	void *cb_arg;
+};
+
+static void
+raid_bdev_add_base_bdev_on_resumed(void *_ctx, int rc)
+{
+	struct raid_bdev_add_base_bdev_ctx *ctx = _ctx;
+
+	if (rc && !ctx->status) {
+		ctx->status = rc;
+	}
+
+	ctx->raid_bdev->base_bdev_updating = false;
+	ctx->cb_fn(ctx->cb_arg, ctx->status);
+	free(ctx->base_bdev_name);
+	free(ctx);
+}
+
+static void
+raid_bdev_add_base_bdev_write_sb_cb(bool success, struct raid_bdev *raid_bdev, void *_ctx)
+{
+	struct raid_bdev_add_base_bdev_ctx *ctx = _ctx;
+
+	if (!success) {
+		SPDK_ERRLOG("Failed to write raid bdev '%s' superblock\n", raid_bdev->bdev.name);
+		ctx->status = -EIO;
+	}
+
+	raid_bdev_resume(raid_bdev, raid_bdev_add_base_bdev_on_resumed, ctx);
+}
+
+static void
+raid_bdev_add_base_bdev_done(struct spdk_io_channel_iter *i, int status)
+{
+	struct raid_bdev_add_base_bdev_ctx *ctx = spdk_io_channel_iter_get_ctx(i);
+	struct raid_bdev *raid_bdev = ctx->raid_bdev;
+	struct raid_base_bdev_info *base_info = &raid_bdev->base_bdev_info[ctx->slot];
+
+	if (status && !ctx->status) {
+		ctx->status = status;
+	}
+
+	if (!ctx->status && raid_bdev->sb) {
+		struct raid_bdev_superblock *sb = raid_bdev->sb;
+		struct raid_bdev_sb_base_bdev *sb_base_bdev;
+		int rc;
+		uint8_t i;
+
+		/* Check if we are filling ah hole */
+		for (i = 0; i < sb->base_bdevs_size; i++) {
+			sb_base_bdev = &sb->base_bdevs[i];
+
+			if (sb_base_bdev->state == RAID_SB_BASE_BDEV_REMOVED &&
+			    sb_base_bdev->slot == ctx->slot) {
+				break;
+			}
+		}
+
+		/* New slot */
+		if (i == sb->base_bdevs_size) {
+			sb_base_bdev = &sb->base_bdevs[i];
+
+			/* Update superblock num base bdevs and length */
+			sb->num_base_bdevs = sb->base_bdevs_size = raid_bdev->num_base_bdevs;
+			sb->length = sizeof(*sb) + sizeof(*sb_base_bdev) * sb->base_bdevs_size;
+		}
+
+		spdk_uuid_copy(&sb_base_bdev->uuid, spdk_bdev_get_uuid(base_info->bdev));
+		sb_base_bdev->data_offset = base_info->data_offset;
+		sb_base_bdev->data_size = base_info->data_size;
+		sb_base_bdev->state = RAID_SB_BASE_BDEV_CONFIGURED;
+		sb_base_bdev->slot = sb_base_bdev - sb->base_bdevs;
+		sb_base_bdev->mode = base_info->mode;
+
+		rc = raid_bdev_write_superblock(raid_bdev, raid_bdev_add_base_bdev_write_sb_cb, ctx);
+		if (rc != 0) {
+			raid_bdev_add_base_bdev_write_sb_cb(false, raid_bdev, ctx);
+		}
+	} else {
+		raid_bdev_resume(raid_bdev, raid_bdev_add_base_bdev_on_resumed, ctx);
+	}
+}
+
+static void
+raid_bdev_channel_add_base_bdev(struct spdk_io_channel_iter *i)
+{
+	struct raid_bdev_add_base_bdev_ctx *ctx = spdk_io_channel_iter_get_ctx(i);
+	struct spdk_io_channel *ch = spdk_io_channel_iter_get_channel(i);
+	struct raid_bdev_io_channel *raid_ch = spdk_io_channel_get_ctx(ch);
+	void *tmp;
+
+	SPDK_DEBUGLOG(bdev_raid, "slot: %u raid_ch: %p\n", ctx->slot, raid_ch);
+
+	/* Check if num_base_bdevs have been incremented */
+	if (raid_ch->num_channels != ctx->raid_bdev->num_base_bdevs) {
+
+		/* Reallocate base_channel array */
+		tmp = realloc(raid_ch->base_channel,
+			      ctx->raid_bdev->num_base_bdevs * sizeof(*raid_ch->base_channel));
+		if (!tmp) {
+			SPDK_ERRLOG("Unable to reallocate raid channel base_channel\n");
+			goto err;
+		}
+		memset(tmp + raid_ch->num_channels * sizeof(*raid_ch->base_channel), 0,
+		       sizeof(*raid_ch->base_channel));
+		raid_ch->base_channel = tmp;
+
+		/* Reallocate base_bdev_modes array */
+		tmp = realloc(raid_ch->base_bdev_modes,
+			      ctx->raid_bdev->num_base_bdevs * sizeof(*raid_ch->base_bdev_modes));
+		if (!tmp) {
+			SPDK_ERRLOG("Unable to reallocate raid channel base_bdev_modes\n");
+			goto err;
+		}
+		memset(tmp + raid_ch->num_channels * sizeof(*raid_ch->base_bdev_modes), 0,
+		       sizeof(*raid_ch->base_bdev_modes));
+		raid_ch->base_bdev_modes = tmp;
+	}
+
+	pthread_mutex_lock(&ctx->raid_bdev->mutex);
+	/* Check for base_channel existence to handle a concurrent channel creation */
+	if (raid_ch->base_channel[ctx->slot] == NULL) {
+		raid_ch->base_channel[ctx->slot] = spdk_bdev_get_io_channel(
+				ctx->raid_bdev->base_bdev_info[ctx->slot].desc);
+	}
+	pthread_mutex_unlock(&ctx->raid_bdev->mutex);
+	if (!raid_ch->base_channel[ctx->slot]) {
+		SPDK_ERRLOG("Unable to create io channel for base bdev\n");
+		goto err;
+	}
+
+	raid_ch->base_bdev_modes[ctx->slot] = ctx->mode;
+
+	if (ctx->raid_bdev->module->channel_add_base_bdev(ctx->raid_bdev, raid_ch) == false) {
+		SPDK_ERRLOG("Unable to add base bdev to raid module channel\n");
+		goto err;
+	}
+	raid_ch->num_channels = ctx->raid_bdev->num_base_bdevs;
+
+	spdk_for_each_channel_continue(i, 0);
+
+	return;
+
+err:
+	spdk_for_each_channel_continue(i, -ENOMEM);
+}
+
+static int
+raid_bdev_add_base_bdev_get_slot(struct raid_bdev *raid_bdev, uint8_t *slot)
+{
+	uint8_t num_base_bdevs = raid_bdev->num_base_bdevs;
+	struct raid_base_bdev_info *base_info;
+	void *tmp;
+	int i;
+
+	/* Check for free slot, because a previous remove operation could have created an hole */
+	for (i = 0; i < raid_bdev->num_base_bdevs; i++) {
+		base_info = &raid_bdev->base_bdev_info[i];
+		if (base_info->name == NULL) {
+			break;
+		}
+	}
+
+	if (base_info->remove_scheduled) {
+		SPDK_ERRLOG("A base bdev remove operation is in progress\n");
+		return -EBUSY;
+	}
+
+	/* If no hole was found, we have to increase num_base_bdevs */
+	if (i == raid_bdev->num_base_bdevs) {
+		num_base_bdevs++;
+
+		tmp = realloc(raid_bdev->base_bdev_info, num_base_bdevs * sizeof(*raid_bdev->base_bdev_info));
+		if (tmp == NULL) {
+			SPDK_ERRLOG("Unable able to reallocate base bdev info\n");
+			return -ENOMEM;
+		}
+		memset(tmp + raid_bdev->num_base_bdevs * sizeof(*raid_bdev->base_bdev_info), 0,
+		       sizeof(*raid_bdev->base_bdev_info));
+		raid_bdev->base_bdev_info = tmp;
+
+		/* Check on min_operational have already been done at raid creation */
+		raid_bdev->min_base_bdevs_operational = raid_bdev_module_get_min_operational(raid_bdev->module,
+							num_base_bdevs);
+
+		raid_bdev->num_base_bdevs = num_base_bdevs;
+	}
+
+	*slot = i;
+
+	return 0;
+}
+
+static void
+raid_bdev_add_base_bdev_on_suspended(struct raid_bdev *raid_bdev, void *_ctx)
+{
+	struct raid_bdev_add_base_bdev_ctx *ctx = _ctx;
+	struct raid_base_bdev_info *base_info;
+	int rc;
+
+	rc = raid_bdev_add_base_bdev_get_slot(ctx->raid_bdev, &ctx->slot);
+	if (rc != 0) {
+		goto err;
+	}
+
+	/* Add base bdev to raid */
+	rc = raid_bdev_add_base_device(raid_bdev, ctx->base_bdev_name, ctx->slot, ctx->mode);
+	base_info = &raid_bdev->base_bdev_info[ctx->slot];
+	if (rc != 0) {
+		/* raid_bdev_add_base_device could need a cleanup in case of error */
+		if (base_info->name != NULL) {
+			pthread_mutex_lock(&raid_bdev->mutex);
+			raid_bdev_free_base_bdev_resource(base_info);
+			pthread_mutex_unlock(&raid_bdev->mutex);
+		}
+
+		goto err;
+	}
+
+	raid_bdev->num_base_bdevs_operational++;
+
+	spdk_for_each_channel(raid_bdev, raid_bdev_channel_add_base_bdev, ctx,
+			      raid_bdev_add_base_bdev_done);
+
+	return;
+
+err:
+	ctx->status = rc;
+	raid_bdev_resume(raid_bdev, raid_bdev_add_base_bdev_on_resumed, ctx);
+}
+
+/*
+ * brief:
+ * raid_bdev_add_base_bdev function add a base bdev in the specified mode to a raid bdev
+ * params:
+ * raid_bdev - pointer to raid bdev
+ * base_bdev - pointer to base bdev
+ * mode - read and write mode of base bdev
+ * returns:
+ * 0 - success
+ * non zero - failure
+ */
+int
+raid_bdev_add_base_bdev(struct raid_bdev *raid_bdev, char *base_bdev_name,
+			enum raid_base_bdev_mode mode, raid_bdev_destruct_cb cb_fn, void *cb_arg)
+{
+	struct raid_bdev_add_base_bdev_ctx *ctx;
+	int i;
+
+	assert(raid_bdev != NULL);
+
+	/* Check if add operation is supported */
+	if (!raid_bdev->module->channel_add_base_bdev) {
+		SPDK_ERRLOG("Raid level does not support adding a base bdev.\n");
+		return -EPERM;
+	}
+
+	/* Check if raid bdev supports this operation */
+	if (raid_bdev_is_mode_supported(raid_bdev, mode) == false) {
+		return -EPERM;
+	}
+
+	assert(spdk_get_thread() == spdk_thread_get_app_thread());
+
+	if (raid_bdev->base_bdev_updating == true) {
+		SPDK_ERRLOG("Another operation is in progress.\n");
+		return -EBUSY;
+	}
+
+	ctx = calloc(1, sizeof(*ctx));
+	if (ctx == NULL) {
+		SPDK_ERRLOG("Unable to allocate memory for add raid bdev context\n");
+		return -ENOMEM;
+	}
+
+	raid_bdev->base_bdev_updating = true;
+
+	ctx->raid_bdev = raid_bdev;
+	ctx->base_bdev_name = strdup(base_bdev_name);
+	ctx->mode = mode;
+	ctx->cb_fn = cb_fn;
+	ctx->cb_arg = cb_arg;
+
+	i = raid_bdev_suspend(raid_bdev, raid_bdev_add_base_bdev_on_suspended, ctx);
+	if (i != 0) {
+		raid_bdev->base_bdev_updating = false;
+		free(ctx);
+	}
+
+	return i;
 }
 
 /*
@@ -2127,8 +2446,8 @@ raid_bdev_configure_base_bdev_load_sb_cb(const struct raid_bdev_superblock *sb, 
 	switch (status) {
 	case 0:
 		/* valid superblock found */
-		SPDK_ERRLOG("Existing raid superblock found on bdev %s\n", base_info->name);
-		raid_bdev_free_base_bdev_resource(base_info);
+		SPDK_WARNLOG("Existing raid superblock found on bdev %s\n", base_info->name);
+		raid_bdev_configure_base_bdev_cont(base_info);
 		break;
 	case -EINVAL:
 		/* no valid superblock */
@@ -2216,8 +2535,6 @@ raid_bdev_configure_base_bdev(struct raid_base_bdev_info *base_info)
 
 	SPDK_DEBUGLOG(bdev_raid, "bdev %s is claimed\n", bdev->name);
 
-	assert(raid_bdev->state != RAID_BDEV_STATE_ONLINE);
-
 	base_info->app_thread_ch = spdk_bdev_get_io_channel(desc);
 	if (base_info->app_thread_ch == NULL) {
 		SPDK_ERRLOG("Failed to get io channel\n");
@@ -2273,7 +2590,8 @@ out:
 
 static int
 _raid_bdev_add_base_device(struct raid_bdev *raid_bdev, const char *name,
-			   const struct spdk_uuid *uuid, uint8_t slot, uint64_t data_offset, uint64_t data_size)
+			   const struct spdk_uuid *uuid, uint8_t slot, uint64_t data_offset, uint64_t data_size,
+			   enum raid_base_bdev_mode mode)
 {
 	struct raid_base_bdev_info *base_info;
 	int rc;
@@ -2312,6 +2630,8 @@ _raid_bdev_add_base_device(struct raid_bdev *raid_bdev, const char *name,
 
 	base_info->data_offset = data_offset;
 	base_info->data_size = data_size;
+	base_info->raid_bdev = raid_bdev;
+	base_info->mode = mode;
 
 	if (name == NULL && uuid == NULL) {
 		return 0;
@@ -2342,11 +2662,12 @@ _raid_bdev_add_base_device(struct raid_bdev *raid_bdev, const char *name,
  * non zero - failure
  */
 int
-raid_bdev_add_base_device(struct raid_bdev *raid_bdev, const char *name, uint8_t slot)
+raid_bdev_add_base_device(struct raid_bdev *raid_bdev, const char *name, uint8_t slot,
+			  enum raid_base_bdev_mode mode)
 {
 	assert(name != NULL);
 
-	return _raid_bdev_add_base_device(raid_bdev, name, NULL, slot, 0, 0);
+	return _raid_bdev_add_base_device(raid_bdev, name, NULL, slot, 0, 0, mode);
 }
 
 static int
@@ -2363,7 +2684,7 @@ raid_bdev_add_base_device_from_sb(struct raid_bdev *raid_bdev,
 	}
 
 	rc = _raid_bdev_add_base_device(raid_bdev, NULL, uuid, sb_base_bdev->slot,
-					sb_base_bdev->data_offset, sb_base_bdev->data_size);
+					sb_base_bdev->data_offset, sb_base_bdev->data_size, sb_base_bdev->mode);
 
 	if (rc == -ENODEV) {
 		rc = 0;

--- a/module/bdev/raid/bdev_raid_rpc.c
+++ b/module/bdev/raid/bdev_raid_rpc.c
@@ -256,7 +256,7 @@ rpc_bdev_raid_create(struct spdk_jsonrpc_request *request,
 	for (i = 0; i < req.base_bdevs.num_base_bdevs; i++) {
 		const char *base_bdev_name = req.base_bdevs.base_bdevs[i];
 
-		rc = raid_bdev_add_base_device(raid_bdev, base_bdev_name, i);
+		rc = raid_bdev_add_base_device(raid_bdev, base_bdev_name, i, RAID_BASE_BDEV_MODE_RW);
 		if (rc == -ENODEV) {
 			SPDK_DEBUGLOG(bdev_raid, "base bdev %s doesn't exist now\n", base_bdev_name);
 		} else if (rc != 0) {
@@ -595,3 +595,145 @@ cleanup:
 }
 SPDK_RPC_REGISTER("bdev_raid_set_base_bdev_mode", rpc_bdev_raid_set_base_bdev_mode,
 		  SPDK_RPC_RUNTIME)
+
+/*
+ * Input structure for RPC rpc_bdev_raid_add_base_bdev
+ */
+struct rpc_bdev_raid_add_base_bdev {
+	/* Raid bdev name */
+	char *raid_bdev_name;
+
+	/* Base bdev name */
+	char *base_bdev_name;
+
+	/* Base bdev read/write mode */
+	enum raid_base_bdev_mode mode;
+};
+
+/*
+ * brief:
+ * free_rpc_bdev_raid_add_base_bdev function is to free RPC bdev_raid_add_base_bdev related parameters
+ * params:
+ * req - pointer to RPC request
+ * returns:
+ * none
+ */
+static void
+free_rpc_bdev_raid_add_base_bdev(struct rpc_bdev_raid_add_base_bdev *req)
+{
+	free(req->raid_bdev_name);
+	free(req->base_bdev_name);
+}
+
+/*
+ * Decoder object for RPC bdev_raid_add_base_bdev
+ */
+static const struct spdk_json_object_decoder rpc_bdev_raid_add_base_bdev_decoders[] = {
+	{"raid_name", offsetof(struct rpc_bdev_raid_add_base_bdev, raid_bdev_name), spdk_json_decode_string},
+	{"base_name", offsetof(struct rpc_bdev_raid_add_base_bdev, base_bdev_name), spdk_json_decode_string},
+	{"mode", offsetof(struct rpc_bdev_raid_add_base_bdev, mode), decode_raid_mode, true},
+};
+
+struct rpc_bdev_raid_add_base_bdev_ctx {
+	struct rpc_bdev_raid_add_base_bdev req;
+	struct spdk_jsonrpc_request *request;
+};
+
+/*
+ * brief:
+ * params:
+ * cb_arg - pointer to the callback context.
+ * rc - return code of the adding a base bdev.
+ * returns:
+ * none
+ */
+static void
+bdev_raid_add_base_bdev_done(void *cb_arg, int rc)
+{
+	struct rpc_bdev_raid_add_base_bdev_ctx *ctx = cb_arg;
+	struct spdk_jsonrpc_request *request = ctx->request;
+
+	if (rc != 0) {
+		SPDK_ERRLOG("Failed to add base bdev %s to raid bdev %s (%d): %s\n",
+			    ctx->req.base_bdev_name, ctx->req.raid_bdev_name, rc, spdk_strerror(-rc));
+		spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_INTERNAL_ERROR,
+						 spdk_strerror(-rc));
+		goto exit;
+	}
+
+	spdk_jsonrpc_send_bool_response(request, true);
+exit:
+	free_rpc_bdev_raid_add_base_bdev(&ctx->req);
+	free(ctx);
+}
+
+/*
+ * brief:
+ * bdev_raid_add_base_bdev function is the RPC for adding a base bdev to a raid bdev.
+ * It takes raid bdev name, base bdev name and optionally base bdev mode as input.
+ * rw is the default mode.
+ * params:
+ * request - pointer to json rpc request
+ * params - pointer to request parameters
+ * returns:
+ * none
+ */
+static void
+rpc_bdev_raid_add_base_bdev(struct spdk_jsonrpc_request *request,
+			    const struct spdk_json_val *params)
+{
+	struct rpc_bdev_raid_add_base_bdev_ctx *ctx;
+	struct raid_bdev *raid_bdev;
+	struct spdk_bdev *base_bdev;
+	int rc;
+
+	ctx = calloc(1, sizeof(*ctx));
+	if (!ctx) {
+		spdk_jsonrpc_send_error_response(request, -ENOMEM, spdk_strerror(ENOMEM));
+		return;
+	}
+
+	if (spdk_json_decode_object(params, rpc_bdev_raid_add_base_bdev_decoders,
+				    SPDK_COUNTOF(rpc_bdev_raid_add_base_bdev_decoders),
+				    &ctx->req)) {
+		spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_PARSE_ERROR,
+						 "spdk_json_decode_object failed");
+		goto cleanup;
+	}
+
+	raid_bdev = raid_bdev_find_by_name(ctx->req.raid_bdev_name);
+	if (raid_bdev == NULL) {
+		spdk_jsonrpc_send_error_response_fmt(request, -ENODEV,
+						     "raid bdev %s not found",
+						     ctx->req.raid_bdev_name);
+		goto cleanup;
+	}
+
+	base_bdev = spdk_bdev_get_by_name(ctx->req.base_bdev_name);
+	if (base_bdev == NULL) {
+		spdk_jsonrpc_send_error_response_fmt(request, -ENODEV,
+						     "base bdev %s not found",
+						     ctx->req.base_bdev_name);
+		goto cleanup;
+	}
+
+	ctx->request = request;
+
+	rc = raid_bdev_add_base_bdev(raid_bdev, ctx->req.base_bdev_name, ctx->req.mode,
+				     bdev_raid_add_base_bdev_done,
+				     ctx);
+	if (rc != 0) {
+		spdk_jsonrpc_send_error_response_fmt(request, rc,
+						     "Failed to add base bdev %s in RAID bdev %s (%s): %s",
+						     ctx->req.base_bdev_name, ctx->req.raid_bdev_name,
+						     raid_bdev_mode_to_str(ctx->req.mode), spdk_strerror(-rc));
+		goto cleanup;
+	}
+
+	return;
+
+cleanup:
+	free_rpc_bdev_raid_add_base_bdev(&ctx->req);
+	free(ctx);
+}
+SPDK_RPC_REGISTER("bdev_raid_add_base_bdev", rpc_bdev_raid_add_base_bdev, SPDK_RPC_RUNTIME)

--- a/module/bdev/raid/bdev_raid_sb.h
+++ b/module/bdev/raid/bdev_raid_sb.h
@@ -19,10 +19,10 @@
 	SPDK_ALIGN_CEIL((sizeof(struct raid_bdev_superblock) + UINT8_MAX * sizeof(struct raid_bdev_sb_base_bdev)), 0x1000)
 
 enum raid_bdev_sb_base_bdev_state {
-	RAID_SB_BASE_BDEV_MISSING	= 0,
+	RAID_SB_BASE_BDEV_MISSING		= 0,
 	RAID_SB_BASE_BDEV_CONFIGURED	= 1,
-	RAID_SB_BASE_BDEV_FAILED	= 2,
-	RAID_SB_BASE_BDEV_SPARE		= 3,
+	RAID_SB_BASE_BDEV_FAILED		= 2,
+	RAID_SB_BASE_BDEV_REMOVED		= 3,
 };
 
 struct raid_bdev_sb_base_bdev {
@@ -38,8 +38,10 @@ struct raid_bdev_sb_base_bdev {
 	uint32_t		flags;
 	/* slot number of this base bdev in the raid */
 	uint8_t			slot;
+	/* Read and write permissions */
+	int8_t			mode;
 
-	uint8_t			reserved[23];
+	uint8_t			reserved[22];
 };
 SPDK_STATIC_ASSERT(sizeof(struct raid_bdev_sb_base_bdev) == 64, "incorrect size");
 

--- a/module/bdev/raid/raid1.c
+++ b/module/bdev/raid/raid1.c
@@ -68,7 +68,7 @@ raid1_channel_next_read_base_bdev(struct raid_bdev_io_channel *raid_ch)
 			idx = 0;
 		}
 
-		if (raid_ch->base_channel[idx]) {
+		if (raid_ch->base_channel[idx] && raid_ch->base_bdev_modes[idx] != RAID_BASE_BDEV_MODE_WO) {
 			raid1_ch->base_bdev_read_idx = idx;
 
 			if (raid1_ch->base_bdev_read_bw[idx] < raid1_ch->base_bdev_max_read_bw) {
@@ -324,6 +324,7 @@ static struct raid_bdev_module g_raid1_module = {
 	.stop = raid1_stop,
 	.submit_rw_request = raid1_submit_rw_request,
 	.get_io_channel = raid1_get_io_channel,
+	.rw_mode_supported = {RAID_BASE_BDEV_MODE_RW, RAID_BASE_BDEV_MODE_WO},
 };
 RAID_MODULE_REGISTER(&g_raid1_module)
 

--- a/python/spdk/rpc/bdev.py
+++ b/python/spdk/rpc/bdev.py
@@ -471,6 +471,25 @@ def bdev_raid_set_base_bdev_mode(client, name, mode):
     return client.call('bdev_raid_set_base_bdev_mode', params)
 
 
+def bdev_raid_add_base_bdev(client, raid_name, base_name, mode=None):
+    """Add a base bdev to an existing raid bdev
+
+    Args:
+        raid_name: raid bdev name
+        base_name: base bdev name
+        mode: read/write mode (optional)
+
+    Returns:
+        None
+    """
+    params = {'raid_name': raid_name, 'base_name': base_name}
+
+    if mode:
+        params['mode'] = mode
+
+    return client.call('bdev_raid_add_base_bdev', params)
+
+
 def bdev_aio_create(client, filename, name, block_size=None, readonly=False):
     """Construct a Linux AIO block device.
 

--- a/python/spdk/rpc/bdev.py
+++ b/python/spdk/rpc/bdev.py
@@ -457,6 +457,20 @@ def bdev_raid_remove_base_bdev(client, name):
     return client.call('bdev_raid_remove_base_bdev', params)
 
 
+def bdev_raid_set_base_bdev_mode(client, name, mode):
+    """Set the read and write mode of a base bdev
+
+    Args:
+        name: base bdev name
+        mode: read/write mode
+
+    Returns:
+        None
+    """
+    params = {'name': name, 'mode': mode}
+    return client.call('bdev_raid_set_base_bdev_mode', params)
+
+
 def bdev_aio_create(client, filename, name, block_size=None, readonly=False):
     """Construct a Linux AIO block device.
 

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -2150,6 +2150,21 @@ Format: 'user:u1 secret:s1 muser:mu1 msecret:ms1,user:u2 secret:s2 muser:mu2 mse
     p.add_argument('mode', help="""read/write mode. 'rw' or 'ro' or 'wo'.""")
     p.set_defaults(func=bdev_raid_set_base_bdev_mode)
 
+    def bdev_raid_add_base_bdev(args):
+        rpc.bdev.bdev_raid_add_base_bdev(args.client,
+                                         raid_name=args.raid_name,
+                                         base_name=args.base_name,
+                                         mode=args.mode)
+    p = subparsers.add_parser('bdev_raid_add_base_bdev',
+                              help="""Add a base bdev to an existing raid bdev.
+                                      Optionally a read/write mode for the base bdev can be passed.
+                                      Modes can be handled with the RPC bdev_raid_set_base_bdev_mode.
+                                      The default mode is 'rw', raid1 supports also 'wo'.""")
+    p.add_argument('raid_name', help='raid bdev name')
+    p.add_argument('base_name', help='base bdev name')
+    p.add_argument('-m', '--mode', help="""read/write mode. 'rw' or 'ro' or 'wo'.'rw' is the default""", required=False)
+    p.set_defaults(func=bdev_raid_add_base_bdev)
+
     # split
     def bdev_split_create(args):
         print_array(rpc.bdev.bdev_split_create(args.client,

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -2138,6 +2138,18 @@ Format: 'user:u1 secret:s1 muser:mu1 msecret:ms1,user:u2 secret:s2 muser:mu2 mse
     p.add_argument('name', help='base bdev name')
     p.set_defaults(func=bdev_raid_remove_base_bdev)
 
+    def bdev_raid_set_base_bdev_mode(args):
+        rpc.bdev.bdev_raid_set_base_bdev_mode(args.client,
+                                              name=args.name,
+                                              mode=args.mode)
+    p = subparsers.add_parser('bdev_raid_set_base_bdev_mode',
+                              help="""Set read/write mode of a raid base bdev. Mode should be one of 'rw', 'ro' or 'wo'.
+                                      'rw' means read and write enabled, 'ro' read only and 'wo' write only.
+                                       All raid levels support 'rw', which is the default. Raid1 supports also 'wo'.""")
+    p.add_argument('name', help='base bdev name')
+    p.add_argument('mode', help="""read/write mode. 'rw' or 'ro' or 'wo'.""")
+    p.set_defaults(func=bdev_raid_set_base_bdev_mode)
+
     # split
     def bdev_split_create(args):
         print_array(rpc.bdev.bdev_split_create(args.client,

--- a/test/unit/lib/bdev/raid/bdev_raid.c/bdev_raid_ut.c
+++ b/test/unit/lib/bdev/raid/bdev_raid.c/bdev_raid_ut.c
@@ -2098,7 +2098,7 @@ test_raid_suspend_resume(void)
 	SPDK_CU_ASSERT_FATAL(rc == 0);
 	poll_threads();
 	CU_ASSERT(suspend_cb_called == true);
-	raid_bdev_resume(pbdev);
+	raid_bdev_resume(pbdev, NULL, NULL);
 	poll_threads();
 
 	/* suspend/resume with one idle io channel */
@@ -2112,7 +2112,7 @@ test_raid_suspend_resume(void)
 	poll_threads();
 	CU_ASSERT(suspend_cb_called == true);
 	CU_ASSERT(raid_ch->is_suspended == true);
-	raid_bdev_resume(pbdev);
+	raid_bdev_resume(pbdev, NULL, NULL);
 	poll_threads();
 	CU_ASSERT(raid_ch->is_suspended == false);
 
@@ -2132,13 +2132,13 @@ test_raid_suspend_resume(void)
 	SPDK_CU_ASSERT_FATAL(rc == 0);
 	CU_ASSERT(suspend_cb_called == true);
 
-	raid_bdev_resume(pbdev);
+	raid_bdev_resume(pbdev, NULL, NULL);
 	poll_threads();
 	CU_ASSERT(raid_ch->is_suspended == true);
-	raid_bdev_resume(pbdev);
+	raid_bdev_resume(pbdev, NULL, NULL);
 	poll_threads();
 	CU_ASSERT(raid_ch->is_suspended == true);
-	raid_bdev_resume(pbdev);
+	raid_bdev_resume(pbdev, NULL, NULL);
 	poll_threads();
 	CU_ASSERT(raid_ch->is_suspended == false);
 
@@ -2167,7 +2167,7 @@ test_raid_suspend_resume(void)
 	CU_ASSERT(raid_ch->num_ios == 0);
 	CU_ASSERT(TAILQ_FIRST(&raid_ch->suspended_ios) == (struct raid_bdev_io *)bdev_io->driver_ctx);
 
-	raid_bdev_resume(pbdev);
+	raid_bdev_resume(pbdev, NULL, NULL);
 	poll_threads();
 	CU_ASSERT(raid_ch->is_suspended == false);
 	verify_io(bdev_io, req.base_bdevs.num_base_bdevs, raid_ch, pbdev, g_child_io_status_flag);
@@ -2245,7 +2245,7 @@ test_raid_suspend_resume_create_ch(void)
 	CU_ASSERT(raid_ch1->is_suspended == true);
 	CU_ASSERT(raid_ch2->is_suspended == true);
 	set_thread(0);
-	raid_bdev_resume(pbdev);
+	raid_bdev_resume(pbdev, NULL, NULL);
 	poll_threads();
 	CU_ASSERT(raid_ch1->is_suspended == false);
 	CU_ASSERT(raid_ch2->is_suspended == false);
@@ -2261,7 +2261,7 @@ test_raid_suspend_resume_create_ch(void)
 	poll_threads();
 	CU_ASSERT(suspend_cb_called == true);
 	CU_ASSERT(raid_ch1->is_suspended == true);
-	raid_bdev_resume(pbdev);
+	raid_bdev_resume(pbdev, NULL, NULL);
 
 	set_thread(2);
 	ch2 = spdk_get_io_channel(pbdev);

--- a/test/unit/lib/bdev/raid/bdev_raid.c/bdev_raid_ut.c
+++ b/test/unit/lib/bdev/raid/bdev_raid.c/bdev_raid_ut.c
@@ -12,6 +12,7 @@
 #include "bdev/raid/bdev_raid.c"
 #include "bdev/raid/bdev_raid_rpc.c"
 #include "bdev/raid/raid0.c"
+#include "bdev/raid/raid1.c"
 #include "common/lib/ut_multithread.c"
 
 #define MAX_BASE_DRIVES 32
@@ -954,13 +955,15 @@ verify_raid_bdev(struct rpc_bdev_raid_create *r, bool presence, uint32_t raid_st
 					min_blockcnt = base_info->data_size;
 				}
 			}
-			CU_ASSERT((((min_blockcnt / (r->strip_size_kb * 1024 / g_block_len)) *
-				    (r->strip_size_kb * 1024 / g_block_len)) *
-				   r->base_bdevs.num_base_bdevs) == pbdev->bdev.blockcnt);
+			if (r->strip_size_kb > 0) {
+				CU_ASSERT((((min_blockcnt / (r->strip_size_kb * 1024 / g_block_len)) *
+					    (r->strip_size_kb * 1024 / g_block_len)) *
+					   r->base_bdevs.num_base_bdevs) == pbdev->bdev.blockcnt);
+			}
 			CU_ASSERT(strcmp(pbdev->bdev.product_name, "Raid Volume") == 0);
 			CU_ASSERT(pbdev->bdev.write_cache == 0);
 			CU_ASSERT(pbdev->bdev.blocklen == g_block_len);
-			if (pbdev->num_base_bdevs > 1) {
+			if (pbdev->num_base_bdevs > 1 && pbdev->level != RAID1) {
 				CU_ASSERT(pbdev->bdev.optimal_io_boundary == pbdev->strip_size);
 				CU_ASSERT(pbdev->bdev.split_on_optimal_io_boundary == true);
 			} else {
@@ -1026,7 +1029,8 @@ create_base_bdevs(uint32_t bbdev_start_idx)
 
 static void
 create_test_req(struct rpc_bdev_raid_create *r, const char *raid_name,
-		uint8_t bbdev_start_idx, bool create_base_bdev, bool superblock)
+		uint8_t bbdev_start_idx, bool create_base_bdev, bool superblock,
+		uint8_t num_base_bdev_to_use)
 {
 	uint8_t i;
 	char name[16];
@@ -1037,8 +1041,8 @@ create_test_req(struct rpc_bdev_raid_create *r, const char *raid_name,
 	r->strip_size_kb = (g_strip_size * g_block_len) / 1024;
 	r->level = RAID0;
 	r->superblock = superblock;
-	r->base_bdevs.num_base_bdevs = g_max_base_drives;
-	for (i = 0; i < g_max_base_drives; i++, bbdev_idx++) {
+	r->base_bdevs.num_base_bdevs = num_base_bdev_to_use;
+	for (i = 0; i < num_base_bdev_to_use; i++, bbdev_idx++) {
 		snprintf(name, 16, "%s%u%s", "Nvme", bbdev_idx, "n1");
 		r->base_bdevs.base_bdevs[i] = strdup(name);
 		SPDK_CU_ASSERT_FATAL(r->base_bdevs.base_bdevs[i] != NULL);
@@ -1051,17 +1055,28 @@ create_test_req(struct rpc_bdev_raid_create *r, const char *raid_name,
 }
 
 static void
-create_raid_bdev_create_req(struct rpc_bdev_raid_create *r, const char *raid_name,
-			    uint8_t bbdev_start_idx, bool create_base_bdev,
-			    uint8_t json_decode_obj_err, bool superblock)
+_create_raid_bdev_create_req(struct rpc_bdev_raid_create *r, const char *raid_name,
+			     uint8_t bbdev_start_idx, bool create_base_bdev,
+			     uint8_t json_decode_obj_err, bool superblock,
+			     uint8_t num_base_bdev_to_use)
 {
-	create_test_req(r, raid_name, bbdev_start_idx, create_base_bdev, superblock);
+	create_test_req(r, raid_name, bbdev_start_idx, create_base_bdev, superblock,
+			num_base_bdev_to_use);
 
 	g_rpc_err = 0;
 	g_json_decode_obj_create = 1;
 	g_json_decode_obj_err = json_decode_obj_err;
 	g_config_level_create = 0;
 	g_test_multi_raids = 0;
+}
+
+static void
+create_raid_bdev_create_req(struct rpc_bdev_raid_create *r, const char *raid_name,
+			    uint8_t bbdev_start_idx, bool create_base_bdev,
+			    uint8_t json_decode_obj_err, bool superblock)
+{
+	_create_raid_bdev_create_req(r, raid_name, bbdev_start_idx, create_base_bdev,
+				     json_decode_obj_err, superblock, g_max_base_drives);
 }
 
 static void
@@ -2366,6 +2381,116 @@ test_raid_set_mode(void)
 	reset_globals();
 }
 
+static void
+test_raid_add_base_bdev_not_supported(void)
+{
+	struct rpc_bdev_raid_create req;
+	struct rpc_bdev_raid_delete destroy_req;
+	struct raid_bdev *pbdev;
+	int rc;
+
+	set_globals();
+	CU_ASSERT(raid_bdev_init() == 0);
+
+	verify_raid_bdev_present("raid1", false);
+	create_raid_bdev_create_req(&req, "raid1", 0, true, 0, false);
+	req.level = RAID0;
+	rpc_bdev_raid_create(NULL, NULL);
+	CU_ASSERT(g_rpc_err == 0);
+
+	TAILQ_FOREACH(pbdev, &g_raid_bdev_list, global_link) {
+		if (strcmp(pbdev->bdev.name, "raid1") == 0) {
+			break;
+		}
+	}
+	CU_ASSERT(pbdev != NULL);
+
+	/* Only RAID1 level actually support add base bdev operation */
+	rc = raid_bdev_add_base_bdev(pbdev, "", RAID_BASE_BDEV_MODE_RW, NULL, NULL);
+	CU_ASSERT(rc == -EPERM);
+	free_test_req(&req);
+
+	create_raid_bdev_delete_req(&destroy_req, "raid1", 0);
+	rpc_bdev_raid_delete(NULL, NULL);
+	CU_ASSERT(g_rpc_err == 0);
+	verify_raid_bdev_present("raid1", false);
+
+	raid_bdev_exit();
+	base_bdevs_cleanup();
+	reset_globals();
+}
+
+static void
+add_base_bdev_cb(void *cb_arg, int rc)
+{
+	*(int *)cb_arg = rc;
+}
+
+static void
+test_raid_add_base_bdev(void)
+{
+	struct rpc_bdev_raid_create req;
+	struct rpc_bdev_raid_delete destroy_req;
+	struct raid_bdev *pbdev;
+	char name[16];
+	struct spdk_io_channel *ch;
+	int add_base_bdev_cb_output;
+	int rc;
+
+	set_globals();
+	CU_ASSERT(raid_bdev_init() == 0);
+
+	snprintf(name, 16, "%s%u%s", "Nvme", g_max_base_drives - 1, "n1");
+
+	/* Create a raid with RAID1 level */
+	verify_raid_bdev_present("raid1", false);
+	_create_raid_bdev_create_req(&req, "raid1", 0, true, 0, false,
+				     g_max_base_drives - 1);
+	req.strip_size_kb = 0;
+	req.level = RAID1;
+	rpc_bdev_raid_create(NULL, NULL);
+	CU_ASSERT(g_rpc_err == 0);
+	verify_raid_bdev(&req, true, RAID_BDEV_STATE_ONLINE);
+
+	TAILQ_FOREACH(pbdev, &g_raid_bdev_list, global_link) {
+		if (strcmp(pbdev->bdev.name, "raid1") == 0) {
+			break;
+		}
+	}
+	CU_ASSERT(pbdev != NULL);
+
+	/* Add base bdev with not supported mode */
+	rc = raid_bdev_add_base_bdev(pbdev, name, RAID_BASE_BDEV_MODE_RO, NULL, NULL);
+	CU_ASSERT(rc == -EPERM);
+
+	/* Add base bdev with supported mode */
+	ch = spdk_get_io_channel(pbdev);
+	SPDK_CU_ASSERT_FATAL(ch != NULL);
+	add_base_bdev_cb_output = 1;
+	rc = raid_bdev_add_base_bdev(pbdev, name, RAID_BASE_BDEV_MODE_WO, add_base_bdev_cb,
+				     &add_base_bdev_cb_output);
+	CU_ASSERT(rc == 0);
+
+	/* Add base bdev with supported mode but with another operation running */
+	rc = raid_bdev_add_base_bdev(pbdev, name, RAID_BASE_BDEV_MODE_RW, NULL, NULL);
+	CU_ASSERT(rc == -EBUSY);
+
+	/* Check that new base bdev has been correctly added */
+	poll_threads();
+	CU_ASSERT(add_base_bdev_cb_output == 0);
+	spdk_put_io_channel(ch);
+	free_test_req(&req);
+
+	create_raid_bdev_delete_req(&destroy_req, "raid1", 0);
+	rpc_bdev_raid_delete(NULL, NULL);
+	CU_ASSERT(g_rpc_err == 0);
+	verify_raid_bdev_present("raid1", false);
+
+	raid_bdev_exit();
+	base_bdevs_cleanup();
+	reset_globals();
+}
+
 int
 main(int argc, char **argv)
 {
@@ -2397,6 +2522,8 @@ main(int argc, char **argv)
 	CU_ADD_TEST(suite, test_raid_suspend_resume);
 	CU_ADD_TEST(suite, test_raid_suspend_resume_create_ch);
 	CU_ADD_TEST(suite, test_raid_set_mode);
+	CU_ADD_TEST(suite, test_raid_add_base_bdev_not_supported);
+	CU_ADD_TEST(suite, test_raid_add_base_bdev);
 
 	allocate_threads(1);
 	set_thread(0);


### PR DESCRIPTION
In this pull request there are 2 main developments:

- introduction of read/write only mode for base bdev of a raid bdev
- adding a new base bdev to an existing raid bdev

These are 2 of the 3 steps needed to implement online rebuilding