### PR TITLE
lvol/blob: fix get shallow copy status

### DIFF
--- a/lib/blob/spdk_blob.map
+++ b/lib/blob/spdk_blob.map
@@ -24,6 +24,7 @@
 	spdk_blob_get_next_unallocated_io_unit;
 	spdk_blob_get_shallow_copy_copied_clusters;
 	spdk_blob_get_shallow_copy_total_clusters;
+	spdk_blob_get_shallow_copy_result;
 	spdk_blob_opts_init;
 	spdk_bs_create_blob_ext;
 	spdk_bs_create_blob;


### PR DESCRIPTION
Function spdk_blob_get_shallow_copy_result has been added to spdk_blob.map file because it is a public API function. It is the check_format script that discovered this lack.