### PR TITLE
lib/json: format fix of append double quote

### DIFF
--- a/lib/json/json_write.c
+++ b/lib/json/json_write.c
@@ -395,7 +395,7 @@ write_string_or_name(struct spdk_json_write_ctx *w, const char *val, size_t len)
 	const uint8_t *end = val + len;
 	bool failed = false;
 	int retval;
-	
+
 
 	if (emit(w, "\"", 1)) { return fail(w); }
 
@@ -430,7 +430,7 @@ write_string_or_name(struct spdk_json_write_ctx *w, const char *val, size_t len)
 		p += codepoint_len;
 	}
 
-	// Always append "\"" in the end of string
+	/* Always append "\"" in the end of string */
 	retval = emit(w, "\"", 1);
 
 	if (failed) {


### PR DESCRIPTION
A couple of format fix shown by check_format.sh in the commit "Always append one double quote char in the end of string".
Just to don't have errors reported by check_format.sh in the future.