### PR TITLE
Lvol snapshot xattrs

### DIFF
--- a/doc/jsonrpc.md
+++ b/doc/jsonrpc.md
@@ -9611,6 +9611,7 @@ Name                    | Optional | Type        | Description
 ----------------------- | -------- | ----------- | -----------
 lvol_name               | Required | string      | UUID or alias of the logical volume to create a snapshot from
 snapshot_name           | Required | string      | Name for the newly created snapshot
+xattrs                  | Optional | string map  | Xattrs for the newly created snapshot
 
 #### Response
 
@@ -9627,7 +9628,11 @@ Example request:
   "id": 1,
   "params": {
     "lvol_name": "1b38702c-7f0c-411e-a962-92c6a5a8a602",
-    "snapshot_name": "SNAP1"
+    "snapshot_name": "SNAP1",
+    "xattrs": {
+      "snapshot_timestamp": "2024-01-16T16:06:46Z",
+      "user_created": "true",
+    }
   }
 }
 ~~~

--- a/doc/lvol.md
+++ b/doc/lvol.md
@@ -169,6 +169,7 @@ bdev_lvol_snapshot [-h] lvol_name snapshot_name
     Create a snapshot with snapshot_name of a given lvol bdev.
     optional arguments:
     -h, --help  show help
+    --xattr adds a key=value xattr to the snapshot.
 bdev_lvol_clone [-h] snapshot_name clone_name
     Create a clone with clone_name of a given lvol snapshot.
     optional arguments:

--- a/include/spdk/lvol.h
+++ b/include/spdk/lvol.h
@@ -217,6 +217,20 @@ void spdk_lvol_create_snapshot(struct spdk_lvol *lvol, const char *snapshot_name
 			       spdk_lvol_op_with_handle_complete cb_fn, void *cb_arg);
 
 /**
+ * Create snapshot of given lvol with xattrs.
+ *
+ * \param lvol Handle to lvol.
+ * \param snapshot_name Name of created snapshot.
+ * \param xattrs Xattrs list for the snapshot (the list has the format par1, val1, par2, val2, ...).
+ * \param xattrs_num Number of elements in the \c xattrs list.
+ * \param cb_fn Completion callback.
+ * \param cb_arg Completion callback custom arguments.
+ */
+void spdk_lvol_create_snapshot_with_xattrs(struct spdk_lvol *lvol, const char *snapshot_name,
+		const char *const *xattrs, size_t xattrs_num,
+		spdk_lvol_op_with_handle_complete cb_fn, void *cb_arg);
+
+/**
  * Create clone of given snapshot.
  *
  * \param lvol Handle to lvol snapshot.

--- a/include/spdk_internal/lvolstore.h
+++ b/include/spdk_internal/lvolstore.h
@@ -77,6 +77,8 @@ struct spdk_lvol_with_handle_req {
 	void				*cb_arg;
 	struct spdk_lvol		*lvol;
 	struct spdk_lvol		*origlvol;
+	char				**xattr_names;
+	char				**xattrs_external;
 };
 
 struct spdk_lvs_degraded_lvol_set;

--- a/lib/lvol/lvol.c
+++ b/lib/lvol/lvol.c
@@ -135,6 +135,44 @@ lvol_free(struct spdk_lvol *lvol)
 }
 
 static void
+lvol_free_xattrs_list(char **xattrs)
+{
+	char **entry;
+
+	if (xattrs) {
+		for (entry = xattrs; *entry; entry++) {
+			free(*entry);
+		}
+		free(xattrs);
+	}
+}
+
+static char **
+lvol_dup_xattr_list(const char *const *xattrs, size_t xattr_num)
+{
+	size_t count;
+	char **copy;
+
+	if (!xattrs) {
+		return NULL;
+	}
+
+	copy = calloc(xattr_num + 1, sizeof(*copy));
+	if (!copy) {
+		return NULL;
+	}
+
+	for (count = 0; count < xattr_num; count++) {
+		if (!(copy[count] = strdup(xattrs[count]))) {
+			lvol_free_xattrs_list(copy);
+			return NULL;
+		}
+	}
+
+	return copy;
+}
+
+static void
 lvol_open_cb(void *cb_arg, struct spdk_blob *blob, int lvolerrno)
 {
 	struct spdk_lvol_with_handle_req *req = cb_arg;
@@ -1078,6 +1116,8 @@ lvol_create_open_cb(void *cb_arg, struct spdk_blob *blob, int lvolerrno)
 
 	if (lvolerrno < 0) {
 		free(lvol);
+		lvol_free_xattrs_list(req->xattrs_external);
+		lvol_free_xattrs_list(req->xattr_names);
 		req->cb_fn(req->cb_arg, NULL, lvolerrno);
 		free(req);
 		return;
@@ -1090,6 +1130,8 @@ lvol_create_open_cb(void *cb_arg, struct spdk_blob *blob, int lvolerrno)
 
 	lvol->ref_count++;
 
+	lvol_free_xattrs_list(req->xattrs_external);
+	lvol_free_xattrs_list(req->xattr_names);
 	assert(req->cb_fn != NULL);
 	req->cb_fn(req->cb_arg, req->lvol, lvolerrno);
 	free(req);
@@ -1105,6 +1147,8 @@ lvol_create_cb(void *cb_arg, spdk_blob_id blobid, int lvolerrno)
 	if (lvolerrno < 0) {
 		TAILQ_REMOVE(&req->lvol->lvol_store->pending_lvols, req->lvol, link);
 		free(req->lvol);
+		lvol_free_xattrs_list(req->xattrs_external);
+		lvol_free_xattrs_list(req->xattr_names);
 		assert(req->cb_fn != NULL);
 		req->cb_fn(req->cb_arg, NULL, lvolerrno);
 		free(req);
@@ -1373,6 +1417,177 @@ spdk_lvol_create_snapshot(struct spdk_lvol *origlvol, const char *snapshot_name,
 	req->origlvol = origlvol;
 	req->cb_fn = cb_fn;
 	req->cb_arg = cb_arg;
+
+	spdk_bs_create_snapshot(lvs->blobstore, spdk_blob_get_id(origblob), &snapshot_xattrs,
+				lvol_create_cb, req);
+}
+
+struct xattrs_ctx {
+	struct spdk_lvol *newlvol;
+	char **xattrs_external;
+};
+
+static void
+lvol_get_xattr_value_ext(void *xattr_ctx, const char *name,
+			 const void **value, size_t *value_len)
+{
+	struct xattrs_ctx *ctx = xattr_ctx;
+	size_t i;
+
+	lvol_get_xattr_value(ctx->newlvol, name, value, value_len);
+
+	if (*value == NULL || *value_len == 0) {
+		/* Search for external xattr */
+		for (i = 0; ctx->xattrs_external[i]; i++) {
+			/* Skip xattrs value, we search xattr names, which are in even positions */
+			if (i % 2 != 0) {
+				continue;
+			}
+
+			if (strcmp(name, ctx->xattrs_external[i]) == 0) {
+				*value = ctx->xattrs_external[i + 1];
+				*value_len = strlen(ctx->xattrs_external[i + 1]) + 1;
+				return;
+			}
+		}
+
+		*value = NULL;
+		*value_len = 0;
+	}
+}
+
+/*
+ * Create a list of xattr names that is the union of the internal xattr names list and the
+ * external xattr name,value list.
+ */
+static char **
+lvol_create_xattrs_names(const char *const *xattr_internal, const char *const *xattr_external,
+			 size_t num_internal, size_t num_external)
+{
+	size_t full_i, ext_i;
+	char **full_list;
+
+	full_list = calloc(num_internal + num_external, sizeof(*full_list));
+	if (!full_list) {
+		return NULL;
+	}
+
+	for (full_i = 0; full_i < num_internal; full_i++) {
+		if (!(full_list[full_i] = strdup(xattr_internal[full_i]))) {
+			lvol_free_xattrs_list(full_list);
+			return NULL;
+		}
+	}
+
+	for (ext_i = 0; ext_i < num_external; ext_i++) {
+		/* Skip xattrs value, we need only xattr names, which are in even positions */
+		if (ext_i % 2 != 0) {
+			continue;
+		}
+
+		if (!(full_list[full_i] = strdup(xattr_external[ext_i]))) {
+			lvol_free_xattrs_list(full_list);
+			return NULL;
+		}
+		full_i++;
+	}
+
+	return full_list;
+}
+
+void
+spdk_lvol_create_snapshot_with_xattrs(struct spdk_lvol *origlvol, const char *snapshot_name,
+				      const char *const *xattrs_external, size_t xattrs_external_num,
+				      spdk_lvol_op_with_handle_complete cb_fn, void *cb_arg)
+{
+	struct spdk_lvol_store *lvs;
+	struct spdk_lvol *newlvol;
+	struct spdk_blob *origblob;
+	struct spdk_lvol_with_handle_req *req;
+	struct spdk_blob_xattr_opts snapshot_xattrs;
+	struct xattrs_ctx xattr_ctx;
+	char **xattr_names;
+	char **xattr_external_dup;
+	char *xattr_names_internal[] = {LVOL_NAME, "uuid", LVOL_CREATION_TIME};
+	int rc;
+
+	if (origlvol == NULL) {
+		SPDK_INFOLOG(lvol, "Lvol not provided.\n");
+		cb_fn(cb_arg, NULL, -EINVAL);
+		return;
+	}
+
+	if (xattrs_external == NULL) {
+		SPDK_WARNLOG("Xattr not provided.\n");
+		return spdk_lvol_create_snapshot(origlvol, snapshot_name, cb_fn, cb_arg);
+	}
+
+	if (xattrs_external_num % 2 != 0) {
+		SPDK_ERRLOG("Xattr list must contain couples of key-value\n");
+		cb_fn(cb_arg, NULL, -EINVAL);
+		return;
+	}
+
+	origblob = origlvol->blob;
+	lvs = origlvol->lvol_store;
+	if (lvs == NULL) {
+		SPDK_ERRLOG("lvol store does not exist\n");
+		cb_fn(cb_arg, NULL, -EINVAL);
+		return;
+	}
+
+	rc = lvs_verify_lvol_name(lvs, snapshot_name);
+	if (rc < 0) {
+		cb_fn(cb_arg, NULL, rc);
+		return;
+	}
+
+	req = calloc(1, sizeof(*req));
+	if (!req) {
+		SPDK_ERRLOG("Cannot alloc memory for lvol request pointer\n");
+		cb_fn(cb_arg, NULL, -ENOMEM);
+		return;
+	}
+
+	newlvol = lvol_alloc(origlvol->lvol_store, snapshot_name, true,
+			     (enum lvol_clear_method)origlvol->clear_method);
+	if (!newlvol) {
+		SPDK_ERRLOG("Cannot alloc memory for lvol base pointer\n");
+		free(req);
+		cb_fn(cb_arg, NULL, -ENOMEM);
+		return;
+	}
+
+	xattr_external_dup = lvol_dup_xattr_list(xattrs_external, xattrs_external_num);
+	if (xattr_external_dup == NULL) {
+		SPDK_ERRLOG("Cannot duplicate external xattr list\n");
+		free(req);
+		cb_fn(cb_arg, NULL, -ENOMEM);
+		return;
+	}
+
+	xattr_names = lvol_create_xattrs_names((const char *const *)&xattr_names_internal, xattrs_external,
+					       SPDK_COUNTOF(xattr_names_internal), xattrs_external_num);
+	if (xattr_names == NULL) {
+		SPDK_ERRLOG("Cannot create xattr name list\n");
+		free(req);
+		lvol_free_xattrs_list(xattr_external_dup);
+		cb_fn(cb_arg, NULL, -ENOMEM);
+		return;
+	}
+
+	xattr_ctx.newlvol = newlvol;
+	xattr_ctx.xattrs_external = xattr_external_dup;
+	snapshot_xattrs.count = SPDK_COUNTOF(xattr_names_internal) + xattrs_external_num / 2;
+	snapshot_xattrs.ctx = &xattr_ctx;
+	snapshot_xattrs.names = xattr_names;
+	snapshot_xattrs.get_value = lvol_get_xattr_value_ext;
+	req->lvol = newlvol;
+	req->origlvol = origlvol;
+	req->cb_fn = cb_fn;
+	req->cb_arg = cb_arg;
+	req->xattr_names = xattr_names;
+	req->xattrs_external = xattr_external_dup;
 
 	spdk_bs_create_snapshot(lvs->blobstore, spdk_blob_get_id(origblob), &snapshot_xattrs,
 				lvol_create_cb, req);

--- a/module/bdev/lvol/vbdev_lvol.c
+++ b/module/bdev/lvol/vbdev_lvol.c
@@ -1448,6 +1448,7 @@ vbdev_lvol_create(struct spdk_lvol_store *lvs, const char *name, uint64_t sz,
 
 void
 vbdev_lvol_create_snapshot(struct spdk_lvol *lvol, const char *snapshot_name,
+			   const char *const *xattrs, size_t xattrs_num,
 			   spdk_lvol_op_with_handle_complete cb_fn, void *cb_arg)
 {
 	struct spdk_lvol_with_handle_req *req;
@@ -1461,7 +1462,15 @@ vbdev_lvol_create_snapshot(struct spdk_lvol *lvol, const char *snapshot_name,
 	req->cb_fn = cb_fn;
 	req->cb_arg = cb_arg;
 
-	spdk_lvol_create_snapshot(lvol, snapshot_name, _vbdev_lvol_create_cb, req);
+	if (xattrs == NULL && xattrs_num == 0) {
+		spdk_lvol_create_snapshot(lvol, snapshot_name, _vbdev_lvol_create_cb, req);
+	} else if (xattrs != NULL && xattrs_num > 0) {
+		spdk_lvol_create_snapshot_with_xattrs(lvol, snapshot_name, xattrs, xattrs_num,
+						      _vbdev_lvol_create_cb, req);
+	} else {
+		cb_fn(cb_arg, NULL, -EINVAL);
+		return;
+	}
 }
 
 void

--- a/module/bdev/lvol/vbdev_lvol.h
+++ b/module/bdev/lvol/vbdev_lvol.h
@@ -39,6 +39,7 @@ int vbdev_lvol_create(struct spdk_lvol_store *lvs, const char *name, uint64_t sz
 		      void *cb_arg);
 
 void vbdev_lvol_create_snapshot(struct spdk_lvol *lvol, const char *snapshot_name,
+				const char *const *xattrs, size_t xattrs_num,
 				spdk_lvol_op_with_handle_complete cb_fn, void *cb_arg);
 
 void vbdev_lvol_create_clone(struct spdk_lvol *lvol, const char *clone_name,

--- a/module/bdev/lvol/vbdev_lvol_rpc.c
+++ b/module/bdev/lvol/vbdev_lvol_rpc.c
@@ -457,7 +457,7 @@ rpc_bdev_lvol_snapshot(struct spdk_jsonrpc_request *request,
 		goto cleanup;
 	}
 
-	vbdev_lvol_create_snapshot(lvol, req.snapshot_name, rpc_bdev_lvol_snapshot_cb, request);
+	vbdev_lvol_create_snapshot(lvol, req.snapshot_name, NULL, 0, rpc_bdev_lvol_snapshot_cb, request);
 
 cleanup:
 	free_rpc_bdev_lvol_snapshot(&req);

--- a/module/bdev/lvol/vbdev_lvol_rpc.c
+++ b/module/bdev/lvol/vbdev_lvol_rpc.c
@@ -390,18 +390,76 @@ SPDK_RPC_REGISTER("bdev_lvol_create", rpc_bdev_lvol_create, SPDK_RPC_RUNTIME)
 struct rpc_bdev_lvol_snapshot {
 	char *lvol_name;
 	char *snapshot_name;
+	char **xattrs;
 };
+
+static void
+bdev_lvol_snapshot_free_xattrs(char **xattrs)
+{
+	char **entry;
+
+	if (xattrs) {
+		for (entry = xattrs; *entry; entry++) {
+			free(*entry);
+		}
+		free(xattrs);
+	}
+}
 
 static void
 free_rpc_bdev_lvol_snapshot(struct rpc_bdev_lvol_snapshot *req)
 {
 	free(req->lvol_name);
 	free(req->snapshot_name);
+	bdev_lvol_snapshot_free_xattrs(req->xattrs);
+}
+
+static int
+bdev_lvol_snapshot_decode_xattrs(const struct spdk_json_val *values, void *out)
+{
+	char ***map = out;
+	char **entry;
+	uint32_t i;
+
+	if (values->type == SPDK_JSON_VAL_NULL) {
+		/* treated like empty object: empty xattrs */
+		*map = calloc(1, sizeof(**map));
+		if (!*map) {
+			return -1;
+		}
+		return 0;
+	}
+
+	if (values->type != SPDK_JSON_VAL_OBJECT_BEGIN) {
+		return -1;
+	}
+
+	*map = calloc(values->len + 1, sizeof(**map));
+	if (!*map) {
+		return -1;
+	}
+
+	for (i = 0, entry = *map; i < values->len;) {
+		const struct spdk_json_val *name = &values[i + 1];
+		const struct spdk_json_val *v = &values[i + 2];
+		/* Here we catch errors like invalid types. */
+		if (!(entry[0] = spdk_json_strdup(name)) ||
+		    !(entry[1] = spdk_json_strdup(v))) {
+			bdev_lvol_snapshot_free_xattrs(*map);
+			*map = NULL;
+			return -1;
+		}
+		i += 1 + spdk_json_val_len(v);
+		entry += 2;
+	}
+
+	return 0;
 }
 
 static const struct spdk_json_object_decoder rpc_bdev_lvol_snapshot_decoders[] = {
 	{"lvol_name", offsetof(struct rpc_bdev_lvol_snapshot, lvol_name), spdk_json_decode_string},
 	{"snapshot_name", offsetof(struct rpc_bdev_lvol_snapshot, snapshot_name), spdk_json_decode_string},
+	{"xattrs", offsetof(struct rpc_bdev_lvol_snapshot, xattrs), bdev_lvol_snapshot_decode_xattrs, true},
 };
 
 static void
@@ -431,6 +489,7 @@ rpc_bdev_lvol_snapshot(struct spdk_jsonrpc_request *request,
 	struct rpc_bdev_lvol_snapshot req = {};
 	struct spdk_bdev *bdev;
 	struct spdk_lvol *lvol;
+	size_t count = 0;
 
 	SPDK_INFOLOG(lvol_rpc, "Snapshotting blob\n");
 
@@ -457,7 +516,13 @@ rpc_bdev_lvol_snapshot(struct spdk_jsonrpc_request *request,
 		goto cleanup;
 	}
 
-	vbdev_lvol_create_snapshot(lvol, req.snapshot_name, NULL, 0, rpc_bdev_lvol_snapshot_cb, request);
+	if (req.xattrs) {
+		for (; req.xattrs[count]; count++) {}
+	}
+
+	vbdev_lvol_create_snapshot(lvol, req.snapshot_name,
+				   (const char *const *)req.xattrs, count,
+				   rpc_bdev_lvol_snapshot_cb, request);
 
 cleanup:
 	free_rpc_bdev_lvol_snapshot(&req);

--- a/python/spdk/rpc/lvol.py
+++ b/python/spdk/rpc/lvol.py
@@ -89,12 +89,13 @@ def bdev_lvol_create(client, lvol_name, size_in_mib, thin_provision=False, uuid=
     return client.call('bdev_lvol_create', params)
 
 
-def bdev_lvol_snapshot(client, lvol_name, snapshot_name):
+def bdev_lvol_snapshot(client, lvol_name, snapshot_name, xattrs=None):
     """Capture a snapshot of the current state of a logical volume.
 
     Args:
         lvol_name: logical volume to create a snapshot from
         snapshot_name: name for the newly created snapshot
+        xattrs: a map of xattr keys to values (optional)
 
     Returns:
         Name of created logical volume snapshot.
@@ -103,6 +104,9 @@ def bdev_lvol_snapshot(client, lvol_name, snapshot_name):
         'lvol_name': lvol_name,
         'snapshot_name': snapshot_name
     }
+    if xattrs is not None:
+        params['xattrs'] = xattrs
+
     return client.call('bdev_lvol_snapshot', params)
 
 

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -1957,13 +1957,24 @@ Format: 'user:u1 secret:s1 muser:mu1 msecret:ms1,user:u2 secret:s2 muser:mu2 mse
     p.set_defaults(func=bdev_lvol_create)
 
     def bdev_lvol_snapshot(args):
+        xattrs = None
+        if args.xattr:
+            xattrs = {}
+            for entry in args.xattr:
+                parts = entry.split('=', 1)
+                if len(parts) != 2:
+                    raise Exception('--xattr %s not in key=value format' % entry)
+                xattrs[parts[0]] = parts[1]
         print_json(rpc.lvol.bdev_lvol_snapshot(args.client,
                                                lvol_name=args.lvol_name,
-                                               snapshot_name=args.snapshot_name))
+                                               snapshot_name=args.snapshot_name,
+                                               xattrs=xattrs))
 
     p = subparsers.add_parser('bdev_lvol_snapshot', help='Create a snapshot of an lvol bdev')
     p.add_argument('lvol_name', help='lvol bdev name')
     p.add_argument('snapshot_name', help='lvol snapshot name')
+    p.add_argument('--xattr', action='append', metavar='key=value',
+                   help="adds a key=value xattr to the snapshot")
     p.set_defaults(func=bdev_lvol_snapshot)
 
     def bdev_lvol_clone(args):

--- a/test/lvol/esnap/esnap.c
+++ b/test/lvol/esnap/esnap.c
@@ -510,7 +510,7 @@ esnap_remove_degraded(void)
 	 * State:
 	 *   esnap <-- vol2 <-- vol1
 	 */
-	vbdev_lvol_create_snapshot(vol1, "vol2", lvol_op_with_handle_cb, clear_owh(&owh_data));
+	vbdev_lvol_create_snapshot(vol1, "vol2", NULL, 0, lvol_op_with_handle_cb, clear_owh(&owh_data));
 	poll_error_updated(&owh_data.lvserrno);
 	SPDK_CU_ASSERT_FATAL(owh_data.lvserrno == 0);
 	SPDK_CU_ASSERT_FATAL(owh_data.u.lvol != NULL);

--- a/test/lvol/xattr.sh
+++ b/test/lvol/xattr.sh
@@ -39,6 +39,11 @@ function test_set_xattr() {
 	snapshot_uuid=$(rpc_cmd bdev_lvol_snapshot lvs_test/lvol_test lvol_snapshot)
 	NOT rpc_cmd bdev_lvol_set_xattr "$snapshot_uuid" "foo" "bar"
 
+	# Create snapshot with xattr
+	snapshotx_uuid=$(rpc_cmd bdev_lvol_snapshot --xattr snapshot_timestamp=2024-01-16T16:06:46Z lvs_test/lvol_test lvol_snapshotx)
+	value=$(rpc_cmd bdev_lvol_get_xattr "$snapshotx_uuid" "snapshot_timestamp")
+	[ "\"2024-01-16T16:06:46Z\"" = "$value" ]
+
 	rpc_cmd bdev_lvol_delete_lvstore -u "$lvs_uuid"
 	rpc_cmd bdev_malloc_delete "$malloc_name"
 	check_leftover_devices

--- a/test/unit/lib/bdev/vbdev_lvol.c/vbdev_lvol_ut.c
+++ b/test/unit/lib/bdev/vbdev_lvol.c/vbdev_lvol_ut.c
@@ -39,6 +39,7 @@ bool g_bdev_alias_already_exists = false;
 bool g_lvs_with_name_already_exists = false;
 bool g_ext_api_called;
 bool g_bdev_is_missing = false;
+bool g_snapshot_xattr_called = false;
 
 DEFINE_STUB_V(spdk_bdev_module_fini_start_done, (void));
 DEFINE_STUB(spdk_bdev_get_memory_domains, int, (struct spdk_bdev *bdev,
@@ -887,6 +888,8 @@ spdk_lvol_create_snapshot_with_xattrs(struct spdk_lvol *lvol, const char *snapsh
 				      const char *const *xattrs, size_t xattrs_num,
 				      spdk_lvol_op_with_handle_complete cb_fn, void *cb_arg)
 {
+	g_snapshot_xattr_called = true;
+	spdk_lvol_create_snapshot(lvol, snapshot_name, cb_fn, cb_arg);
 }
 
 void
@@ -1066,6 +1069,7 @@ ut_lvol_snapshot(void)
 	int sz = 10;
 	int rc;
 	struct spdk_lvol *lvol = NULL;
+	char *xattrs[] = {"par", "val"};
 
 	/* Lvol store is successfully created */
 	rc = vbdev_lvs_create("bdev", "lvs", 0, LVS_CLEAR_WITH_UNMAP, 0,
@@ -1087,10 +1091,31 @@ ut_lvol_snapshot(void)
 	lvol = g_lvol;
 
 	/* Successful snap create */
-	vbdev_lvol_create_snapshot(lvol, "snap", vbdev_lvol_create_complete, NULL);
+	vbdev_lvol_create_snapshot(lvol, "snap", NULL, 0, vbdev_lvol_create_complete, NULL);
 	SPDK_CU_ASSERT_FATAL(rc == 0);
 	CU_ASSERT(g_lvol != NULL);
 	CU_ASSERT(g_lvolerrno == 0);
+	CU_ASSERT(g_snapshot_xattr_called == false);
+
+	/* Snap create with NULL xattrs and xattrs number > 0 */
+	g_lvol = NULL;
+	vbdev_lvol_create_snapshot(lvol, "snap2", NULL, 2,
+				   vbdev_lvol_create_complete, NULL);
+	CU_ASSERT(g_lvol == NULL);
+	CU_ASSERT(g_lvolerrno == -EINVAL);
+
+	/* Snap create with valid xattrs and 0 xattrs number */
+	vbdev_lvol_create_snapshot(lvol, "snap2", (const char *const *)&xattrs, 0,
+				   vbdev_lvol_create_complete, NULL);
+	CU_ASSERT(g_lvol == NULL);
+	CU_ASSERT(g_lvolerrno == -EINVAL);
+
+	/* Successful snap create with xattr */
+	vbdev_lvol_create_snapshot(lvol, "snap4", (const char *const *)&xattrs, 2,
+				   vbdev_lvol_create_complete, NULL);
+	CU_ASSERT(g_lvol != NULL);
+	CU_ASSERT(g_lvolerrno == 0);
+	CU_ASSERT(g_snapshot_xattr_called == true);
 
 	/* Successful lvol destroy */
 	vbdev_lvol_destroy(g_lvol, lvol_store_op_complete, NULL);
@@ -1137,7 +1162,7 @@ ut_lvol_clone(void)
 	lvol = g_lvol;
 
 	/* Successful snap create */
-	vbdev_lvol_create_snapshot(lvol, "snap", vbdev_lvol_create_complete, NULL);
+	vbdev_lvol_create_snapshot(lvol, "snap", NULL, 0, vbdev_lvol_create_complete, NULL);
 	SPDK_CU_ASSERT_FATAL(rc == 0);
 	SPDK_CU_ASSERT_FATAL(g_lvol != NULL);
 	CU_ASSERT(g_lvolerrno == 0);

--- a/test/unit/lib/bdev/vbdev_lvol.c/vbdev_lvol_ut.c
+++ b/test/unit/lib/bdev/vbdev_lvol.c/vbdev_lvol_ut.c
@@ -883,6 +883,13 @@ spdk_lvol_create_snapshot(struct spdk_lvol *lvol, const char *snapshot_name,
 }
 
 void
+spdk_lvol_create_snapshot_with_xattrs(struct spdk_lvol *lvol, const char *snapshot_name,
+				      const char *const *xattrs, size_t xattrs_num,
+				      spdk_lvol_op_with_handle_complete cb_fn, void *cb_arg)
+{
+}
+
+void
 spdk_lvol_create_clone(struct spdk_lvol *lvol, const char *clone_name,
 		       spdk_lvol_op_with_handle_complete cb_fn, void *cb_arg)
 {

--- a/test/unit/lib/lvol/lvol.c/lvol_ut.c
+++ b/test/unit/lib/lvol/lvol.c/lvol_ut.c
@@ -1595,6 +1595,98 @@ lvol_snapshot_fail(void)
 }
 
 static void
+lvol_snapshot_xattr(void)
+{
+	struct lvol_ut_bs_dev dev;
+	struct spdk_lvol *lvol, *snap;
+	struct spdk_lvs_opts opts;
+	int rc = 0;
+	char *xattrs[] = {"snapshot_timestamp", "2024-01-16T16:06:46Z", "user_created", "true"};
+	char *xattrs_bad[] = {"snapshot_timestamp"};
+	const char *value = NULL;
+	size_t value_len = 0;
+	struct xattrs_ctx xattr_ctx;
+
+	init_dev(&dev);
+
+	spdk_lvs_opts_init(&opts);
+	snprintf(opts.name, sizeof(opts.name), "lvs");
+
+	g_lvserrno = -1;
+	rc = spdk_lvs_init(&dev.bs_dev, &opts, lvol_store_op_with_handle_complete, NULL);
+	CU_ASSERT(rc == 0);
+	CU_ASSERT(g_lvserrno == 0);
+	SPDK_CU_ASSERT_FATAL(g_lvol_store != NULL);
+
+	spdk_lvol_create(g_lvol_store, "lvol", 10, true, LVOL_CLEAR_WITH_DEFAULT,
+			 lvol_op_with_handle_complete, NULL);
+	CU_ASSERT(g_lvserrno == 0);
+	SPDK_CU_ASSERT_FATAL(g_lvol != NULL);
+
+	lvol = g_lvol;
+
+	/* Without xattrs, fallback over spdk_lvol_create_snapshot */
+	spdk_lvol_create_snapshot_with_xattrs(lvol, "snap", NULL, 0, lvol_op_with_handle_complete, NULL);
+	CU_ASSERT(g_lvserrno == 0);
+	SPDK_CU_ASSERT_FATAL(g_lvol != NULL);
+	CU_ASSERT_STRING_EQUAL(g_lvol->name, "snap");
+
+	snap = g_lvol;
+
+	/* Should be able to look up name */
+	xattr_ctx.newlvol = lvol;
+	xattr_ctx.xattrs_external = (char **)&xattrs;
+	lvol_get_xattr_value_ext(&xattr_ctx, "name", (const void **)&value, &value_len);
+	CU_ASSERT(value != NULL && strcmp(value, "lvol") == 0);
+	CU_ASSERT(value_len != 0);
+
+	/* With a bad xattrs list */
+	g_lvol = NULL;
+	spdk_lvol_create_snapshot_with_xattrs(lvol, "snap_x", (const char *const *)&xattrs_bad, 1,
+					      lvol_op_with_handle_complete, NULL);
+	CU_ASSERT(g_lvserrno == -EINVAL);
+	CU_ASSERT(g_lvol == NULL);
+
+	/* With a valid xattr list */
+	spdk_lvol_create_snapshot_with_xattrs(lvol, "snap_x", (const char *const *)&xattrs, 4,
+					      lvol_op_with_handle_complete, NULL);
+	CU_ASSERT(g_lvserrno == 0);
+	CU_ASSERT(g_lvol != NULL);
+	CU_ASSERT_STRING_EQUAL(g_lvol->name, "snap_x");
+
+	/* Should be able to look up name, snapshot_timestamp and user_created */
+	lvol_get_xattr_value_ext(&xattr_ctx, "name", (const void **)&value, &value_len);
+	CU_ASSERT(value != NULL && strcmp(value, "lvol") == 0);
+	CU_ASSERT(value_len != 0);
+	lvol_get_xattr_value_ext(&xattr_ctx, "snapshot_timestamp", (const void **)&value, &value_len);
+	CU_ASSERT(value != NULL && strcmp(value, "2024-01-16T16:06:46Z") == 0);
+	CU_ASSERT(value_len != 0);
+	lvol_get_xattr_value_ext(&xattr_ctx, "user_created", (const void **)&value, &value_len);
+	CU_ASSERT(value != NULL && strcmp(value, "true") == 0);
+	CU_ASSERT(value_len != 0);
+
+	/* Lvols has to be closed (or destroyed) before unloading lvol store. */
+	spdk_lvol_close(g_lvol, op_complete, NULL);
+	CU_ASSERT(g_lvserrno == 0);
+	g_lvserrno = -1;
+
+	spdk_lvol_close(snap, op_complete, NULL);
+	CU_ASSERT(g_lvserrno == 0);
+	g_lvserrno = -1;
+
+	spdk_lvol_close(lvol, op_complete, NULL);
+	CU_ASSERT(g_lvserrno == 0);
+	g_lvserrno = -1;
+
+	rc = spdk_lvs_unload(g_lvol_store, op_complete, NULL);
+	CU_ASSERT(rc == 0);
+	CU_ASSERT(g_lvserrno == 0);
+	g_lvol_store = NULL;
+
+	free_dev(&dev);
+}
+
+static void
 lvol_clone(void)
 {
 	struct lvol_ut_bs_dev dev;
@@ -3410,6 +3502,7 @@ main(int argc, char **argv)
 	CU_ADD_TEST(suite, lvol_open);
 	CU_ADD_TEST(suite, lvol_snapshot);
 	CU_ADD_TEST(suite, lvol_snapshot_fail);
+	CU_ADD_TEST(suite, lvol_snapshot_xattr);
 	CU_ADD_TEST(suite, lvol_clone);
 	CU_ADD_TEST(suite, lvol_clone_fail);
 	CU_ADD_TEST(suite, lvol_iter_clones);


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue #7578
Issue #7641

#### What this PR does / why we need it:

We need to set some flags into the snapshot, and this can be done only during the creation. Because once the snapshot is created, its metadata become read only and so xattrs can't be set anymore.

#### Special notes for your reviewer:

#### Additional documentation or context
