### PR TITLE
bdev/nvme: Delay callbacks when the next operation is a failover

### DIFF
--- a/module/bdev/nvme/bdev_nvme.c
+++ b/module/bdev/nvme/bdev_nvme.c
@@ -2034,7 +2034,8 @@ _bdev_nvme_reset_ctrlr_complete(struct spdk_io_channel_iter *i, int status)
 	op_after_reset = bdev_nvme_check_op_after_reset(nvme_ctrlr, success);
 	pthread_mutex_unlock(&nvme_ctrlr->mutex);
 
-	if (ctrlr_op_cb_fn) {
+	/* Delay callbacks when the next operation is a failover. */
+	if (ctrlr_op_cb_fn && op_after_reset != OP_FAILOVER) {
 		ctrlr_op_cb_fn(ctrlr_op_cb_arg, success ? 0 : -1);
 	}
 
@@ -2050,6 +2051,8 @@ _bdev_nvme_reset_ctrlr_complete(struct spdk_io_channel_iter *i, int status)
 		nvme_ctrlr_disconnect(nvme_ctrlr, bdev_nvme_start_reconnect_delay_timer);
 		break;
 	case OP_FAILOVER:
+		nvme_ctrlr->ctrlr_op_cb_fn = ctrlr_op_cb_fn;
+		nvme_ctrlr->ctrlr_op_cb_arg = ctrlr_op_cb_arg;
 		bdev_nvme_failover_ctrlr(nvme_ctrlr);
 		break;
 	default:


### PR DESCRIPTION
Previously, when failover was the next operation after a reset, callbacks notified the `bdev` layer about the successful operation, and scheduled another reset.

This patch ensures that there is no ongoing failover when a successful callback is sent.

Fixes issue #3206.

Change-Id: I649204a8d8f9fa05684ad9ce0fb0a5d94989cfae

Reviewed-on: https://review.spdk.io/gerrit/c/spdk/spdk/+/21901
Reviewed-by: Shuhei Matsumoto <smatsumoto@nvidia.com>
Community-CI: Mellanox Build Bot
Tested-by: SPDK CI Jenkins <sys_sgci@intel.com>
Reviewed-by: Aleksey Marchuk <alexeymar@nvidia.com>
Reviewed-by: Jim Harris <jim.harris@samsung.com>

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/8354

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
