### PR TITLE
Longhorn v24.05

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+#### Which issue(s) this PR fixes:
+<!--
+Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
+-->
+Issue #
+
+#### What this PR does / why we need it:
+
+#### Special notes for your reviewer:
+
+#### Additional documentation or context

--- a/doc/jsonrpc.md
+++ b/doc/jsonrpc.md
@@ -502,6 +502,7 @@ Example response:
     "bdev_lvol_check_shallow_copy",
     "bdev_lvol_set_parent",
     "bdev_lvol_set_parent_bdev",
+    "bdev_lvol_get_fragmap",
     "bdev_daos_delete",
     "bdev_daos_create",
     "bdev_daos_resize"
@@ -10823,6 +10824,52 @@ Example response:
     "state": "in progress",
     "copied_clusters": 2,
     "total_clusters": 4
+  }
+}
+~~~
+
+### bdev_lvol_get_fragmap {#bdev_lvol_get_fragmap}
+
+Get a fragmap for a specific segment of a logical volume using the provided offset and size.
+A fragmap is a bitmap that records the allocation status of clusters. A value of "1" indicates
+that a cluster is allocated, whereas "0" signifies that a cluster is unallocated.
+
+#### Parameters
+
+Name                    | Optional | Type        | Description
+----------------------- | -------- | ----------- | -----------
+name                    | Required | string      | UUID or alias of the logical volume
+offset                  | Optional | number      | Offset in bytes of the specific segment of the logical volume (Default: 0)
+size                    | Optional | number      | Size in bytes of the specific segment of the logical volume (Default: 0 for representing the entire file)
+
+#### Example
+
+Example request:
+
+~~~json
+{
+  "jsonrpc": "2.0",
+  "method": "bdev_lvol_get_fragmap",
+  "id": 1,
+  "params": {
+    "name": "8a47421a-20cf-444f-845c-d97ad0b0bd8e",
+    "offset": 0,
+    "size": 41943040
+  }
+}
+~~~
+
+Example response:
+
+~~~json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "cluster_size": 4194304,
+    "num_clusters": 10,
+    "num_allocated_clusters": 0,
+    "fragmap": "AAA="
   }
 }
 ~~~

--- a/doc/jsonrpc.md
+++ b/doc/jsonrpc.md
@@ -10649,6 +10649,18 @@ Example response:
 ]
 ~~~
 
+### bdev_lvol_set_xattr {#rpc_bdev_lvol_set_xattr}
+
+Set xattr for lvol bdev
+
+#### Parameters
+
+Name                    | Optional | Type        | Description
+----------------------- | -------- | ----------- | -----------
+name                    | Required | string      | UUID or alias of lvol
+xattr_name              | Required | string      | Name of the xattr
+xattr_value             | Required | string      | Value of the xattr
+
 ### bdev_lvol_set_parent {#rpc_bdev_lvol_set_parent}
 
 Set a snapshot as the parent of a lvol, making the lvol a clone of this snapshot.

--- a/doc/jsonrpc.md
+++ b/doc/jsonrpc.md
@@ -10661,6 +10661,17 @@ name                    | Required | string      | UUID or alias of lvol
 xattr_name              | Required | string      | Name of the xattr
 xattr_value             | Required | string      | Value of the xattr
 
+### bdev_lvol_get_xattr {#rpc_bdev_lvol_get_xattr}
+
+Get xattr for lvol bdev
+
+#### Parameters
+
+Name                    | Optional | Type        | Description
+----------------------- | -------- | ----------- | -----------
+name                    | Required | string      | UUID or alias of lvol
+xattr_name              | Required | string      | Name of the xattr
+
 ### bdev_lvol_set_parent {#rpc_bdev_lvol_set_parent}
 
 Set a snapshot as the parent of a lvol, making the lvol a clone of this snapshot.

--- a/doc/jsonrpc.md
+++ b/doc/jsonrpc.md
@@ -10259,6 +10259,7 @@ Name                    | Optional | Type        | Description
 ----------------------- | -------- | ----------- | -----------
 lvol_name               | Required | string      | UUID or alias of the logical volume to create a snapshot from
 snapshot_name           | Required | string      | Name for the newly created snapshot
+xattrs                  | Optional | string map  | Xattrs for the newly created snapshot
 
 #### Response
 
@@ -10275,7 +10276,11 @@ Example request:
   "id": 1,
   "params": {
     "lvol_name": "1b38702c-7f0c-411e-a962-92c6a5a8a602",
-    "snapshot_name": "SNAP1"
+    "snapshot_name": "SNAP1",
+    "xattrs": {
+      "snapshot_timestamp": "2024-01-16T16:06:46Z",
+      "user_created": "true",
+    }
   }
 }
 ~~~

--- a/doc/jsonrpc.md
+++ b/doc/jsonrpc.md
@@ -11119,6 +11119,44 @@ Example response:
 }
 ~~~
 
+### bdev_raid_grow_base_bdev {#rpc_bdev_raid_grow_base_bdev}
+
+Add base bdev to existing raid bdev, growing the raid's size if there isn't an empty base bdev slot.
+The bdev must be large enough and have the same block size and metadata format as the other base bdevs.
+
+#### Parameters
+
+Name                    | Optional | Type        | Description
+----------------------- | -------- | ----------- | -----------
+raid_name               | Required | string      | Raid bdev name
+base_name               | Required | string      | Base bdev name
+
+#### Example
+
+Example request:
+
+~~~json
+{
+  "jsonrpc": "2.0",
+  "method": "bdev_raid_grow_base_bdev",
+  "id": 1,
+  "params": {
+    "raid_name": "Raid1",
+    "base_name": "Nvme1n1",
+  }
+}
+~~~
+
+Example response:
+
+~~~json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": true
+}
+~~~
+
 ## SPLIT
 
 ### bdev_split_create {#rpc_bdev_split_create}

--- a/doc/lvol.md
+++ b/doc/lvol.md
@@ -169,6 +169,7 @@ bdev_lvol_snapshot [-h] lvol_name snapshot_name
     Create a snapshot with snapshot_name of a given lvol bdev.
     optional arguments:
     -h, --help  show help
+    --xattr adds a key=value xattr to the snapshot.
 bdev_lvol_clone [-h] snapshot_name clone_name
     Create a clone with clone_name of a given lvol snapshot.
     optional arguments:

--- a/doc/lvol.md
+++ b/doc/lvol.md
@@ -215,4 +215,8 @@ bdev_lvol_set_parent_bdev lvol_name esnap_name
     Set the parent external snapshot of a lvol
     optional arguments:
     -h, --help  show help
+bdev_lvol_set_xattr [-h] name xattr_name xattr_value
+    Set xattr for lvol bdev
+    optional arguments:
+    -h, --help  show help
 ```

--- a/doc/lvol.md
+++ b/doc/lvol.md
@@ -219,4 +219,8 @@ bdev_lvol_set_xattr [-h] name xattr_name xattr_value
     Set xattr for lvol bdev
     optional arguments:
     -h, --help  show help
+bdev_lvol_get_xattr [-h] name xattr_name
+    Get xattr for lvol bdev
+    optional arguments:
+    -h, --help  show help
 ```

--- a/include/spdk/bdev.h
+++ b/include/spdk/bdev.h
@@ -604,6 +604,14 @@ const char *spdk_bdev_get_name(const struct spdk_bdev *bdev);
 const char *spdk_bdev_get_product_name(const struct spdk_bdev *bdev);
 
 /**
+ * Get block device creation time.
+ *
+ * \param bdev Block device to query.
+ * \return Creation time of bdev as a null-terminated string, or NULL if not present.
+ */
+const char *spdk_bdev_get_creation_time(const struct spdk_bdev *bdev);
+
+/**
  * Get block device logical block size.
  *
  * \param bdev Block device to query.

--- a/include/spdk/bdev_module.h
+++ b/include/spdk/bdev_module.h
@@ -530,6 +530,13 @@ struct spdk_bdev {
 	 */
 	struct spdk_uuid uuid;
 
+	/**
+	 * Creation time for this bdev.
+	 *
+	 * If not provided, it will be NULL.
+	 */
+	const char *creation_time;
+
 	/** Size in bytes of a metadata for the backend */
 	uint32_t md_len;
 

--- a/include/spdk/bit_array.h
+++ b/include/spdk/bit_array.h
@@ -168,6 +168,14 @@ void spdk_bit_array_load_mask(struct spdk_bit_array *ba, const void *mask);
  */
 void spdk_bit_array_clear_mask(struct spdk_bit_array *ba);
 
+/**
+ * Encode a bit array into a base64 string.
+ *
+ * @param array Bit array to encode.
+ * @return base64 string.
+ */
+char *spdk_bit_array_to_base64_string(const struct spdk_bit_array *array);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/spdk/lvol.h
+++ b/include/spdk/lvol.h
@@ -22,6 +22,7 @@ extern "C" {
 struct spdk_bs_dev;
 struct spdk_lvol_store;
 struct spdk_lvol;
+struct spdk_fragmap;
 
 enum lvol_clear_method {
 	LVOL_CLEAR_WITH_DEFAULT = BLOB_CLEAR_WITH_DEFAULT,
@@ -115,6 +116,16 @@ typedef void (*spdk_lvol_op_with_handle_complete)(void *cb_arg, struct spdk_lvol
  * \param lvolerrno Error
  */
 typedef void (*spdk_lvol_op_complete)(void *cb_arg, int lvolerrno);
+
+/**
+ * Callback definition for lvol operations with handle to fragmap
+ *
+ * @param cb_arg Custom arguments
+ * @param fragmap Handle to fragmap or NULL when lvolerrno is set
+ * @param lvolerrno Error
+ */
+typedef void (*spdk_lvol_op_with_fragmap_handle_complete)(void *cb_arg,
+		struct spdk_fragmap *fragmap, int lvolerrno);
 
 /**
  * Callback definition for spdk_lvol_iter_clones.

--- a/include/spdk/lvol.h
+++ b/include/spdk/lvol.h
@@ -275,6 +275,18 @@ spdk_lvol_set_xattr(struct spdk_lvol *lvol, const char *name, const char *value,
 		    spdk_lvol_op_complete cb_fn, void *cb_arg);
 
 /**
+ * Get lvol's xattr.
+ *
+ * \param lvol Handle to lvol.
+ * \param name Xattr name.
+ * \param value Xattr value.
+ * \param value_len Xattr value length.
+ */
+int
+spdk_lvol_get_xattr(struct spdk_lvol *lvol, const char *name,
+		    const void **value, size_t *value_len);
+
+/**
  * \brief Returns if it is possible to delete an lvol (i.e. lvol is not a snapshot that have at least one clone).
  * \param lvol Handle to lvol
  */

--- a/include/spdk/lvol.h
+++ b/include/spdk/lvol.h
@@ -37,8 +37,8 @@ enum lvs_clear_method {
 };
 
 /* Must include null terminator. */
-#define SPDK_LVS_NAME_MAX	64
-#define SPDK_LVOL_NAME_MAX	64
+#define SPDK_LVS_NAME_MAX	256
+#define SPDK_LVOL_NAME_MAX	256
 
 /**
  * Parameters for lvolstore initialization.
@@ -70,7 +70,7 @@ struct spdk_lvs_opts {
 	 */
 	spdk_bs_esnap_dev_create esnap_bs_dev_create;
 } __attribute__((packed));
-SPDK_STATIC_ASSERT(sizeof(struct spdk_lvs_opts) == 88, "Incorrect size");
+SPDK_STATIC_ASSERT(sizeof(struct spdk_lvs_opts) == 280, "Incorrect size");
 
 /**
  * Initialize an spdk_lvs_opts structure to the defaults.

--- a/include/spdk/lvol.h
+++ b/include/spdk/lvol.h
@@ -217,6 +217,20 @@ void spdk_lvol_create_snapshot(struct spdk_lvol *lvol, const char *snapshot_name
 			       spdk_lvol_op_with_handle_complete cb_fn, void *cb_arg);
 
 /**
+ * Create snapshot of given lvol with xattrs.
+ *
+ * \param lvol Handle to lvol.
+ * \param snapshot_name Name of created snapshot.
+ * \param xattrs Xattrs list for the snapshot (the list has the format par1, val1, par2, val2, ...).
+ * \param xattrs_num Number of elements in the \c xattrs list.
+ * \param cb_fn Completion callback.
+ * \param cb_arg Completion callback custom arguments.
+ */
+void spdk_lvol_create_snapshot_with_xattrs(struct spdk_lvol *lvol, const char *snapshot_name,
+		const char *const *xattrs, size_t xattrs_num,
+		spdk_lvol_op_with_handle_complete cb_fn, void *cb_arg);
+
+/**
  * Create clone of given snapshot.
  *
  * \param lvol Handle to lvol snapshot.

--- a/include/spdk/lvol.h
+++ b/include/spdk/lvol.h
@@ -262,6 +262,19 @@ spdk_lvol_rename(struct spdk_lvol *lvol, const char *new_name,
 		 spdk_lvol_op_complete cb_fn, void *cb_arg);
 
 /**
+ * Set lvol's xattr.
+ *
+ * \param lvol Handle to lvol.
+ * \param name xattr name.
+ * \param value xattr value.
+ * \param cb_fn Completion callback.
+ * \param cb_arg Completion callback custom arguments.
+ */
+void
+spdk_lvol_set_xattr(struct spdk_lvol *lvol, const char *name, const char *value,
+		    spdk_lvol_op_complete cb_fn, void *cb_arg);
+
+/**
  * \brief Returns if it is possible to delete an lvol (i.e. lvol is not a snapshot that have at least one clone).
  * \param lvol Handle to lvol
  */

--- a/include/spdk/util.h
+++ b/include/spdk/util.h
@@ -376,6 +376,26 @@ spdk_is_divisible_by(uint64_t dividend, uint64_t divisor)
 	return (dividend & (divisor - 1)) == 0;
 }
 
+/*
+ * Get the UTC time string in RFC3339 format.
+ *
+ * \param buf Buffer to store the UTC time string.
+ * \param buf_size Size of the buffer.
+ *
+ * \return void
+ */
+static inline void
+spdk_current_utc_time_rfc3339(char *buf, size_t buf_size)
+{
+	struct tm *utc;
+	time_t rawtime;
+
+	time(&rawtime);
+	utc = gmtime(&rawtime);
+
+	strftime(buf, buf_size, "%Y-%m-%dT%H:%M:%SZ", utc);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/spdk/util.h
+++ b/include/spdk/util.h
@@ -362,6 +362,20 @@ spdk_memset_s(void *data, size_t data_size, int ch, size_t count)
 #endif
 }
 
+/**
+ * @brief Check if \b dividend is divisible by \b divisor
+ *
+ * @param dividend Dividend
+ * @param divisor Divisor which is a power of 2
+ * @return true
+ * @return false
+ */
+static inline bool
+spdk_is_divisible_by(uint64_t dividend, uint64_t divisor)
+{
+	return (dividend & (divisor - 1)) == 0;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/spdk_internal/lvolstore.h
+++ b/include/spdk_internal/lvolstore.h
@@ -77,6 +77,8 @@ struct spdk_lvol_with_handle_req {
 	void				*cb_arg;
 	struct spdk_lvol		*lvol;
 	struct spdk_lvol		*origlvol;
+	char				**xattr_names;
+	char				**xattrs_external;
 };
 
 struct spdk_lvol_bs_dev_req {

--- a/include/spdk_internal/lvolstore.h
+++ b/include/spdk_internal/lvolstore.h
@@ -123,6 +123,30 @@ struct spdk_lvol {
 	TAILQ_ENTRY(spdk_lvol)		degraded_link;
 };
 
+struct spdk_fragmap {
+	struct spdk_bit_array *map;
+
+	uint64_t cluster_size;
+	uint64_t block_size;
+	uint64_t num_clusters;
+	uint64_t num_allocated_clusters;
+};
+
+struct spdk_fragmap_req {
+	struct spdk_bdev *bdev;
+	struct spdk_bdev_desc *bdev_desc;
+	struct spdk_io_channel *bdev_io_channel;
+
+	struct spdk_fragmap fragmap;
+
+	uint64_t offset;
+	uint64_t size;
+	uint64_t current_offset;
+
+	spdk_lvol_op_with_fragmap_handle_complete cb_fn;
+	void *cb_arg;
+};
+
 struct lvol_store_bdev *vbdev_lvol_store_first(void);
 struct lvol_store_bdev *vbdev_lvol_store_next(struct lvol_store_bdev *prev);
 

--- a/include/spdk_internal/lvolstore.h
+++ b/include/spdk_internal/lvolstore.h
@@ -16,6 +16,9 @@
 /* Default size of blobstore cluster */
 #define SPDK_LVS_OPTS_CLUSTER_SZ (4 * 1024 * 1024)
 
+/* Creation time format in RFC 3339 format */
+#define SPDK_CREATION_TIME_MAX 21 /* 20 characters + null terminator */
+
 /* UUID + '_' + blobid (20 characters for uint64_t).
  * Null terminator is already included in SPDK_UUID_STRING_LEN. */
 #define SPDK_LVOL_UNIQUE_ID_MAX (SPDK_UUID_STRING_LEN + 1 + 20)
@@ -114,6 +117,7 @@ struct spdk_lvol {
 	char				name[SPDK_LVOL_NAME_MAX];
 	struct spdk_uuid		uuid;
 	char				uuid_str[SPDK_UUID_STRING_LEN];
+	char				creation_time[SPDK_CREATION_TIME_MAX];
 	struct spdk_bdev		*bdev;
 	int				ref_count;
 	bool				action_in_progress;

--- a/lib/bdev/bdev.c
+++ b/lib/bdev/bdev.c
@@ -4714,6 +4714,12 @@ spdk_bdev_get_aliases(const struct spdk_bdev *bdev)
 	return &bdev->aliases;
 }
 
+const char *
+spdk_bdev_get_creation_time(const struct spdk_bdev *bdev)
+{
+	return bdev->creation_time;
+}
+
 uint32_t
 spdk_bdev_get_block_size(const struct spdk_bdev *bdev)
 {

--- a/lib/bdev/bdev_rpc.c
+++ b/lib/bdev/bdev_rpc.c
@@ -633,6 +633,7 @@ rpc_dump_bdev_info(void *ctx, struct spdk_bdev *bdev)
 	struct spdk_bdev_alias *tmp;
 	uint64_t qos_limits[SPDK_BDEV_QOS_NUM_RATE_LIMIT_TYPES];
 	struct spdk_memory_domain **domains;
+	const char *creation_time_str;
 	int i, rc;
 
 	spdk_json_write_object_begin(w);
@@ -651,6 +652,12 @@ rpc_dump_bdev_info(void *ctx, struct spdk_bdev *bdev)
 	spdk_json_write_named_uint32(w, "block_size", spdk_bdev_get_block_size(bdev));
 	spdk_json_write_named_uint64(w, "num_blocks", spdk_bdev_get_num_blocks(bdev));
 	spdk_json_write_named_uuid(w, "uuid", &bdev->uuid);
+
+	creation_time_str = spdk_bdev_get_creation_time(bdev);
+	if (creation_time_str == NULL) {
+		creation_time_str = "";
+	}
+	spdk_json_write_named_string(w, "creation_time", creation_time_str);
 
 	if (spdk_bdev_get_md_size(bdev) != 0) {
 		spdk_json_write_named_uint32(w, "md_size", spdk_bdev_get_md_size(bdev));

--- a/lib/lvol/lvol.c
+++ b/lib/lvol/lvol.c
@@ -652,7 +652,7 @@ lvs_opts_copy(const struct spdk_lvs_opts *src, struct spdk_lvs_opts *dst)
 
 	/* You should not remove this statement, but need to update the assert statement
 	 * if you add a new field, and also add a corresponding SET_FIELD statement */
-	SPDK_STATIC_ASSERT(sizeof(struct spdk_lvs_opts) == 88, "Incorrect size");
+	SPDK_STATIC_ASSERT(sizeof(struct spdk_lvs_opts) == 280, "Incorrect size");
 
 #undef FIELD_OK
 #undef SET_FIELD

--- a/lib/lvol/lvol.c
+++ b/lib/lvol/lvol.c
@@ -1584,6 +1584,15 @@ spdk_lvol_set_xattr(struct spdk_lvol *lvol, const char *name, const char *value,
 	spdk_blob_sync_md(blob, lvol_set_xattr_cb, req);
 }
 
+int
+spdk_lvol_get_xattr(struct spdk_lvol *lvol, const char *name,
+		    const void **value, size_t *value_len)
+{
+	struct spdk_blob *blob = lvol->blob;
+
+	return spdk_blob_get_xattr_value(blob, name, value, value_len);
+}
+
 void
 spdk_lvol_destroy(struct spdk_lvol *lvol, spdk_lvol_op_complete cb_fn, void *cb_arg)
 {

--- a/lib/lvol/spdk_lvol.map
+++ b/lib/lvol/spdk_lvol.map
@@ -13,6 +13,7 @@
 	spdk_lvol_create_snapshot;
 	spdk_lvol_create_clone;
 	spdk_lvol_rename;
+	spdk_lvol_set_xattr;
 	spdk_lvol_deletable;
 	spdk_lvol_destroy;
 	spdk_lvol_close;

--- a/lib/lvol/spdk_lvol.map
+++ b/lib/lvol/spdk_lvol.map
@@ -14,6 +14,7 @@
 	spdk_lvol_create_clone;
 	spdk_lvol_rename;
 	spdk_lvol_set_xattr;
+	spdk_lvol_get_xattr;
 	spdk_lvol_deletable;
 	spdk_lvol_destroy;
 	spdk_lvol_close;

--- a/lib/util/spdk_util.map
+++ b/lib/util/spdk_util.map
@@ -22,6 +22,7 @@
 	spdk_bit_array_store_mask;
 	spdk_bit_array_load_mask;
 	spdk_bit_array_clear_mask;
+	spdk_bit_array_to_base64_string;
 
 	# public functions in bit_pool.h
 	spdk_bit_pool_capacity;

--- a/module/bdev/lvol/vbdev_lvol.c
+++ b/module/bdev/lvol/vbdev_lvol.c
@@ -1366,7 +1366,7 @@ _vbdev_lvol_set_xattr_cb(void *cb_arg, int lvolerrno)
 	struct spdk_lvol_req *req = cb_arg;
 
 	if (lvolerrno != 0) {
-		SPDK_ERRLOG("Setting xattr failed\n");
+		SPDK_ERRLOG("Setting xattr failed: error %d\n", lvolerrno);
 	}
 
 	req->cb_fn(req->cb_arg, lvolerrno);

--- a/module/bdev/lvol/vbdev_lvol.c
+++ b/module/bdev/lvol/vbdev_lvol.c
@@ -1144,6 +1144,7 @@ _create_lvol_disk(struct spdk_lvol *lvol, bool destroy)
 	assert((total_size % bdev->blocklen) == 0);
 	bdev->blockcnt = total_size / bdev->blocklen;
 	bdev->uuid = lvol->uuid;
+	bdev->creation_time = lvol->creation_time;
 	bdev->required_alignment = lvs_bdev->bdev->required_alignment;
 	bdev->split_on_optimal_io_boundary = true;
 	bdev->optimal_io_boundary = spdk_bs_get_cluster_size(lvol->lvol_store->blobstore) / bdev->blocklen;

--- a/module/bdev/lvol/vbdev_lvol.c
+++ b/module/bdev/lvol/vbdev_lvol.c
@@ -1360,6 +1360,36 @@ vbdev_lvol_rename(struct spdk_lvol *lvol, const char *new_lvol_name,
 }
 
 static void
+_vbdev_lvol_set_xattr_cb(void *cb_arg, int lvolerrno)
+{
+	struct spdk_lvol_req *req = cb_arg;
+
+	if (lvolerrno != 0) {
+		SPDK_ERRLOG("Setting xattr failed\n");
+	}
+
+	req->cb_fn(req->cb_arg, lvolerrno);
+	free(req);
+}
+
+void
+vbdev_lvol_set_xattr(struct spdk_lvol *lvol, const char *name,
+		     const char *value, spdk_lvol_op_complete cb_fn, void *cb_arg)
+{
+	struct spdk_lvol_req *req;
+
+	req = calloc(1, sizeof(*req));
+	if (req == NULL) {
+		cb_fn(cb_arg, -ENOMEM);
+		return;
+	}
+	req->cb_fn = cb_fn;
+	req->cb_arg = cb_arg;
+
+	spdk_lvol_set_xattr(lvol, name, value, _vbdev_lvol_set_xattr_cb, req);
+}
+
+static void
 _vbdev_lvol_resize_cb(void *cb_arg, int lvolerrno)
 {
 	struct spdk_lvol_req *req = cb_arg;

--- a/module/bdev/lvol/vbdev_lvol.c
+++ b/module/bdev/lvol/vbdev_lvol.c
@@ -1389,6 +1389,13 @@ vbdev_lvol_set_xattr(struct spdk_lvol *lvol, const char *name,
 	spdk_lvol_set_xattr(lvol, name, value, _vbdev_lvol_set_xattr_cb, req);
 }
 
+int
+vbdev_lvol_get_xattr(struct spdk_lvol *lvol, const char *name,
+		     const void **value, size_t *value_len)
+{
+	return spdk_lvol_get_xattr(lvol, name, value, value_len);
+}
+
 static void
 _vbdev_lvol_resize_cb(void *cb_arg, int lvolerrno)
 {

--- a/module/bdev/lvol/vbdev_lvol.c
+++ b/module/bdev/lvol/vbdev_lvol.c
@@ -1228,6 +1228,7 @@ vbdev_lvol_create(struct spdk_lvol_store *lvs, const char *name, uint64_t sz,
 
 void
 vbdev_lvol_create_snapshot(struct spdk_lvol *lvol, const char *snapshot_name,
+			   const char *const *xattrs, size_t xattrs_num,
 			   spdk_lvol_op_with_handle_complete cb_fn, void *cb_arg)
 {
 	struct spdk_lvol_with_handle_req *req;
@@ -1241,7 +1242,15 @@ vbdev_lvol_create_snapshot(struct spdk_lvol *lvol, const char *snapshot_name,
 	req->cb_fn = cb_fn;
 	req->cb_arg = cb_arg;
 
-	spdk_lvol_create_snapshot(lvol, snapshot_name, _vbdev_lvol_create_cb, req);
+	if (xattrs == NULL && xattrs_num == 0) {
+		spdk_lvol_create_snapshot(lvol, snapshot_name, _vbdev_lvol_create_cb, req);
+	} else if (xattrs != NULL && xattrs_num > 0) {
+		spdk_lvol_create_snapshot_with_xattrs(lvol, snapshot_name, xattrs, xattrs_num,
+						      _vbdev_lvol_create_cb, req);
+	} else {
+		cb_fn(cb_arg, NULL, -EINVAL);
+		return;
+	}
 }
 
 void

--- a/module/bdev/lvol/vbdev_lvol.h
+++ b/module/bdev/lvol/vbdev_lvol.h
@@ -40,6 +40,7 @@ int vbdev_lvol_create(struct spdk_lvol_store *lvs, const char *name, uint64_t sz
 		      void *cb_arg);
 
 void vbdev_lvol_create_snapshot(struct spdk_lvol *lvol, const char *snapshot_name,
+				const char *const *xattrs, size_t xattrs_num,
 				spdk_lvol_op_with_handle_complete cb_fn, void *cb_arg);
 
 void vbdev_lvol_create_clone(struct spdk_lvol *lvol, const char *clone_name,

--- a/module/bdev/lvol/vbdev_lvol.h
+++ b/module/bdev/lvol/vbdev_lvol.h
@@ -71,6 +71,17 @@ void vbdev_lvol_rename(struct spdk_lvol *lvol, const char *new_lvol_name,
 		       spdk_lvol_op_complete cb_fn, void *cb_arg);
 
 /**
+ * \brief Set lvol's xattr
+ * \param lvol Handle to lvol
+ * \param name xattr name
+ * \param value xattr value
+ * \param cb_fn Completion callback
+ * \param cb_arg Completion callback custom arguments
+ */
+void vbdev_lvol_set_xattr(struct spdk_lvol *lvol, const char *name,
+			  const char *value, spdk_lvol_op_complete cb_fn, void *cb_arg);
+
+/**
  * Destroy a logical volume
  * \param lvol Handle to lvol
  * \param cb_fn Completion callback

--- a/module/bdev/lvol/vbdev_lvol.h
+++ b/module/bdev/lvol/vbdev_lvol.h
@@ -82,6 +82,16 @@ void vbdev_lvol_set_xattr(struct spdk_lvol *lvol, const char *name,
 			  const char *value, spdk_lvol_op_complete cb_fn, void *cb_arg);
 
 /**
+ * \brief Get lvol's xattr
+ * \param lvol Handle to lvol
+ * \param name Xattr name
+ * \param value Xattr value
+ * \param value_len Xattr value length
+ */
+int vbdev_lvol_get_xattr(struct spdk_lvol *lvol, const char *name,
+			 const void **value, size_t *value_len);
+
+/**
  * Destroy a logical volume
  * \param lvol Handle to lvol
  * \param cb_fn Completion callback

--- a/module/bdev/lvol/vbdev_lvol.h
+++ b/module/bdev/lvol/vbdev_lvol.h
@@ -143,4 +143,16 @@ int vbdev_lvol_shallow_copy(struct spdk_lvol *lvol, const char *bdev_name,
 void vbdev_lvol_set_external_parent(struct spdk_lvol *lvol, const char *esnap_name,
 				    spdk_lvol_op_complete cb_fn, void *cb_arg);
 
+/**
+ * @brief Get a fragmap for a specific segment of a logical volume using the provided offset and size
+ *
+ * @param lvol Handle to lvol
+ * @param offset Offset in bytes of the specific segment of the logical volume
+ * @param size Size in bytes of the specific segment of the logical volume
+ * @param cb_fn Completion callback
+ * @param cb_arg Completion callback custom arguments
+ */
+void vbdev_lvol_get_fragmap(struct spdk_lvol *lvol, uint64_t offset, uint64_t size,
+			    spdk_lvol_op_with_fragmap_handle_complete cb_fn, void *cb_arg);
+
 #endif /* SPDK_VBDEV_LVOL_H */

--- a/module/bdev/lvol/vbdev_lvol_rpc.c
+++ b/module/bdev/lvol/vbdev_lvol_rpc.c
@@ -1320,6 +1320,7 @@ rpc_dump_lvol(struct spdk_json_write_ctx *w, struct spdk_lvol *lvol)
 	spdk_json_write_named_string_fmt(w, "alias", "%s/%s", lvs->name, lvol->name);
 	spdk_json_write_named_string(w, "uuid", lvol->uuid_str);
 	spdk_json_write_named_string(w, "name", lvol->name);
+	spdk_json_write_named_string(w, "creation_time", lvol->creation_time);
 	spdk_json_write_named_bool(w, "is_thin_provisioned", spdk_blob_is_thin_provisioned(lvol->blob));
 	spdk_json_write_named_bool(w, "is_snapshot", spdk_blob_is_snapshot(lvol->blob));
 	spdk_json_write_named_bool(w, "is_clone", spdk_blob_is_clone(lvol->blob));

--- a/module/bdev/lvol/vbdev_lvol_rpc.c
+++ b/module/bdev/lvol/vbdev_lvol_rpc.c
@@ -10,6 +10,8 @@
 #include "vbdev_lvol.h"
 #include "spdk/string.h"
 #include "spdk/log.h"
+#include "spdk/bdev_module.h"
+#include "spdk/bit_array.h"
 
 SPDK_LOG_REGISTER_COMPONENT(lvol_rpc)
 
@@ -1649,3 +1651,96 @@ cleanup:
 
 SPDK_RPC_REGISTER("bdev_lvol_set_parent_bdev", rpc_bdev_lvol_set_parent_bdev,
 		  SPDK_RPC_RUNTIME)
+
+struct rpc_bdev_lvol_get_fragmap {
+	char *name;
+	uint64_t offset;
+	uint64_t size;
+};
+
+static void
+free_rpc_bdev_lvol_get_fragmap(struct rpc_bdev_lvol_get_fragmap *r)
+{
+	free(r->name);
+}
+
+static const struct spdk_json_object_decoder rpc_bdev_lvol_get_fragmap_decoders[] = {
+	{"name", offsetof(struct rpc_bdev_lvol_get_fragmap, name), spdk_json_decode_string, true},
+	{"offset", offsetof(struct rpc_bdev_lvol_get_fragmap, offset), spdk_json_decode_uint64, true},
+	{"size", offsetof(struct rpc_bdev_lvol_get_fragmap, size), spdk_json_decode_uint64, true},
+};
+
+static void
+rpc_bdev_lvol_get_fragmap_cb(void *cb_arg, struct spdk_fragmap *fragmap, int lvolerrno)
+{
+	struct spdk_json_write_ctx *w;
+	struct spdk_jsonrpc_request *request = cb_arg;
+	char *encoded;
+
+	if (lvolerrno != 0) {
+		goto invalid;
+	}
+
+	encoded = spdk_bit_array_to_base64_string(fragmap->map);
+	if (encoded == NULL) {
+		SPDK_ERRLOG("Failed to encode fragmap to base64 string\n");
+		lvolerrno = -EINVAL;
+		goto invalid;
+	}
+
+	w = spdk_jsonrpc_begin_result(request);
+	spdk_json_write_object_begin(w);
+
+	spdk_json_write_named_uint64(w, "cluster_size", fragmap->cluster_size);
+	spdk_json_write_named_uint64(w, "num_clusters", fragmap->num_clusters);
+	spdk_json_write_named_uint64(w, "num_allocated_clusters", fragmap->num_allocated_clusters);
+	spdk_json_write_named_string(w, "fragmap", encoded);
+
+	spdk_json_write_object_end(w);
+	spdk_jsonrpc_end_result(request, w);
+
+	free(encoded);
+	return;
+
+invalid:
+	spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_INVALID_PARAMS,
+					 spdk_strerror(-lvolerrno));
+}
+
+static void
+rpc_bdev_lvol_get_fragmap(struct spdk_jsonrpc_request *request, const struct spdk_json_val *params)
+{
+	struct rpc_bdev_lvol_get_fragmap req = {};
+	struct spdk_bdev *bdev;
+	struct spdk_lvol *lvol;
+
+	if (spdk_json_decode_object(params, rpc_bdev_lvol_get_fragmap_decoders,
+				    SPDK_COUNTOF(rpc_bdev_lvol_get_fragmap_decoders),
+				    &req)) {
+		SPDK_ERRLOG("spdk_json_decode_object failed\n");
+		spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_INTERNAL_ERROR,
+						 "spdk_json_decode_object failed");
+		goto cleanup;
+	}
+
+	bdev = spdk_bdev_get_by_name(req.name);
+	if (bdev == NULL) {
+		SPDK_ERRLOG("bdev '%s' does not exist\n", req.name);
+		spdk_jsonrpc_send_error_response(request, -ENODEV, spdk_strerror(ENODEV));
+		goto cleanup;
+	}
+
+	lvol = vbdev_lvol_get_from_bdev(bdev);
+	if (lvol == NULL) {
+		SPDK_ERRLOG("lvol does not exist\n");
+		spdk_jsonrpc_send_error_response(request, -ENODEV, spdk_strerror(ENODEV));
+		goto cleanup;
+	}
+
+	vbdev_lvol_get_fragmap(lvol, req.offset, req.size, rpc_bdev_lvol_get_fragmap_cb, request);
+
+cleanup:
+	free_rpc_bdev_lvol_get_fragmap(&req);
+}
+
+SPDK_RPC_REGISTER("bdev_lvol_get_fragmap", rpc_bdev_lvol_get_fragmap, SPDK_RPC_RUNTIME)

--- a/module/bdev/lvol/vbdev_lvol_rpc.c
+++ b/module/bdev/lvol/vbdev_lvol_rpc.c
@@ -451,7 +451,7 @@ rpc_bdev_lvol_snapshot(struct spdk_jsonrpc_request *request,
 		goto cleanup;
 	}
 
-	vbdev_lvol_create_snapshot(lvol, req.snapshot_name, rpc_bdev_lvol_snapshot_cb, request);
+	vbdev_lvol_create_snapshot(lvol, req.snapshot_name, NULL, 0, rpc_bdev_lvol_snapshot_cb, request);
 
 cleanup:
 	free_rpc_bdev_lvol_snapshot(&req);

--- a/module/bdev/raid/bdev_raid.c
+++ b/module/bdev/raid/bdev_raid.c
@@ -33,6 +33,9 @@ struct raid_bdev_io_channel {
 	/* Array of IO channels of base bdevs */
 	struct spdk_io_channel	**base_channel;
 
+	/* Number of IO channels */
+	uint8_t			num_channels;
+
 	/* Private raid module IO channel */
 	struct spdk_io_channel	*module_channel;
 
@@ -156,6 +159,12 @@ raid_bdev_channel_get_base_info(struct raid_bdev_io_channel *raid_ch, struct spd
 	return NULL;
 }
 
+uint8_t
+raid_bdev_channel_get_num_channels(struct raid_bdev_io_channel *raid_ch)
+{
+	return raid_ch->num_channels;
+}
+
 static uint8_t
 raid_bdev_module_get_min_operational(const char *name, struct raid_bdev_module *module,
 				     uint8_t num_base_bdevs)
@@ -277,6 +286,7 @@ raid_bdev_create_cb(void *io_device, void *ctx_buf)
 	assert(raid_bdev != NULL);
 	assert(raid_bdev->state == RAID_BDEV_STATE_ONLINE);
 
+	raid_ch->num_channels = raid_bdev->num_base_bdevs;
 	raid_ch->base_channel = calloc(raid_bdev->num_base_bdevs, sizeof(struct spdk_io_channel *));
 	if (!raid_ch->base_channel) {
 		SPDK_ERRLOG("Unable to allocate base bdevs io channel\n");
@@ -1768,9 +1778,13 @@ raid_bdev_configure(struct raid_bdev *raid_bdev)
 	uint32_t data_block_size = spdk_bdev_get_data_block_size(&raid_bdev->bdev);
 	int rc;
 
-	assert(raid_bdev->state == RAID_BDEV_STATE_CONFIGURING);
 	assert(raid_bdev->num_base_bdevs_discovered == raid_bdev->num_base_bdevs_operational);
 	assert(raid_bdev->bdev.blocklen > 0);
+
+	/* Check if raid is already configured: it is true in the case we are growing the raid */
+	if (raid_bdev->state == RAID_BDEV_STATE_ONLINE) {
+		return 0;
+	}
 
 	/* The strip_size_kb is read in from user in KB. Convert to blocks here for
 	 * internal use.
@@ -1882,6 +1896,7 @@ raid_bdev_remove_base_bdev_done(struct raid_base_bdev_info *base_info, int statu
 	struct raid_bdev *raid_bdev = base_info->raid_bdev;
 
 	assert(base_info->remove_scheduled);
+	raid_bdev->base_bdev_updating = false;
 	base_info->remove_scheduled = false;
 
 	if (status == 0) {
@@ -2129,6 +2144,12 @@ _raid_bdev_remove_base_bdev(struct raid_base_bdev_info *base_info,
 		return -ENODEV;
 	}
 
+	if (raid_bdev->base_bdev_updating == true) {
+		SPDK_ERRLOG("Another operation is in progress.\n");
+		return -EBUSY;
+	}
+	raid_bdev->base_bdev_updating = true;
+
 	assert(base_info->desc);
 	base_info->remove_scheduled = true;
 
@@ -2142,6 +2163,7 @@ _raid_bdev_remove_base_bdev(struct raid_base_bdev_info *base_info,
 		 */
 		raid_bdev_free_base_bdev_resource(base_info);
 		base_info->remove_scheduled = false;
+		raid_bdev->base_bdev_updating = false;
 		if (raid_bdev->num_base_bdevs_discovered == 0 &&
 		    raid_bdev->state == RAID_BDEV_STATE_OFFLINE) {
 			/* There is no base bdev for this raid, so free the raid device. */
@@ -2154,6 +2176,7 @@ _raid_bdev_remove_base_bdev(struct raid_base_bdev_info *base_info,
 		/* This raid bdev does not tolerate removing a base bdev. */
 		raid_bdev->num_base_bdevs_operational--;
 		raid_bdev_deconfigure(raid_bdev, cb_fn, cb_ctx);
+		raid_bdev->base_bdev_updating = false;
 	} else {
 		base_info->remove_cb = cb_fn;
 		base_info->remove_cb_ctx = cb_ctx;
@@ -2166,6 +2189,7 @@ _raid_bdev_remove_base_bdev(struct raid_base_bdev_info *base_info,
 
 		if (ret != 0) {
 			base_info->remove_scheduled = false;
+			raid_bdev->base_bdev_updating = false;
 		}
 	}
 
@@ -3041,10 +3065,10 @@ static void
 raid_bdev_configure_base_bdev_cont(struct raid_base_bdev_info *base_info)
 {
 	struct raid_bdev *raid_bdev = base_info->raid_bdev;
-	int rc;
+	int rc = 0;
 
 	if (raid_bdev->num_base_bdevs_discovered == raid_bdev->num_base_bdevs_operational &&
-	    base_info->is_process_target == false) {
+	    base_info->is_process_target == false && base_info->skip_rebuild == false) {
 		/* TODO: defer if rebuild in progress on another base bdev */
 		assert(raid_bdev->process == NULL);
 		assert(raid_bdev->state == RAID_BDEV_STATE_ONLINE);
@@ -3079,8 +3103,8 @@ raid_bdev_configure_base_bdev_cont(struct raid_base_bdev_info *base_info)
 			SPDK_ERRLOG("Failed to start rebuild: %s\n", spdk_strerror(-rc));
 			_raid_bdev_remove_base_bdev(base_info, NULL, NULL);
 		}
-	} else {
-		rc = 0;
+	} else if (raid_bdev->num_base_bdevs_discovered > raid_bdev->num_base_bdevs_operational) {
+		raid_bdev->num_base_bdevs_operational++;
 	}
 
 	if (base_info->configure_cb != NULL) {
@@ -3373,6 +3397,379 @@ raid_bdev_add_base_bdev(struct raid_bdev *raid_bdev, const char *name,
 		SPDK_ERRLOG("base bdev '%s' configure failed: %s\n", name, spdk_strerror(-rc));
 		free(base_info->name);
 		base_info->name = NULL;
+	}
+
+	return rc;
+}
+
+struct raid_bdev_grow_base_bdev_ctx {
+	struct raid_bdev *raid_bdev;
+	char *base_bdev_name;
+	/* Status is the result of the operation, 0 if successful otherwise -ERRNO */
+	int status;
+	uint8_t slot;
+	raid_bdev_destruct_cb cb_fn;
+	void *cb_arg;
+};
+
+static void
+raid_bdev_grow_base_bdev_done(struct raid_bdev_grow_base_bdev_ctx *ctx, int status)
+{
+	if (status && !ctx->status) {
+		ctx->status = status;
+	}
+
+	ctx->raid_bdev->base_bdev_updating = false;
+	if (ctx->cb_fn != NULL) {
+		ctx->cb_fn(ctx->cb_arg, ctx->status);
+	}
+
+	free(ctx->base_bdev_name);
+	free(ctx);
+}
+
+static void
+raid_bdev_grow_base_bdev_write_sb_cb(int status, struct raid_bdev *raid_bdev, void *_ctx)
+{
+	struct raid_bdev_grow_base_bdev_ctx *ctx = _ctx;
+
+	if (status != 0) {
+		SPDK_ERRLOG("Failed to write raid bdev '%s' superblock: %s\n",
+			    raid_bdev->bdev.name, spdk_strerror(-status));
+	}
+
+	raid_bdev_grow_base_bdev_done(ctx, status);
+}
+
+static void
+raid_bdev_grow_base_bdev_on_unquiesced(void *_ctx, int status)
+{
+	struct raid_bdev_grow_base_bdev_ctx *ctx = _ctx;
+	struct raid_bdev *raid_bdev = ctx->raid_bdev;
+	struct raid_base_bdev_info *base_info = &raid_bdev->base_bdev_info[ctx->slot];
+
+	if (status != 0) {
+		SPDK_ERRLOG("Failed to unquiesce raid bdev %s: %s\n",
+			    raid_bdev->bdev.name, spdk_strerror(-status));
+		goto out;
+	}
+
+	if (!ctx->status && raid_bdev->sb) {
+		struct raid_bdev_superblock *sb = raid_bdev->sb;
+		struct raid_bdev_sb_base_bdev *sb_base_bdev = NULL;
+		uint8_t i;
+
+		/* Check if we are filling an hole */
+		for (i = 0; i < sb->base_bdevs_size; i++) {
+			sb_base_bdev = &sb->base_bdevs[i];
+
+			if (sb_base_bdev->state == RAID_SB_BASE_BDEV_MISSING &&
+			    sb_base_bdev->slot == ctx->slot) {
+				break;
+			}
+		}
+
+		/* New slot */
+		if (i == sb->base_bdevs_size) {
+			sb_base_bdev = &sb->base_bdevs[i];
+
+			/* Update superblock num base bdevs and length */
+			sb->num_base_bdevs = sb->base_bdevs_size = raid_bdev->num_base_bdevs;
+			sb->length = sizeof(*sb) + sizeof(*sb_base_bdev) * sb->base_bdevs_size;
+		}
+
+		assert(sb_base_bdev != NULL);
+
+		spdk_uuid_copy(&sb_base_bdev->uuid, &base_info->uuid);
+		sb_base_bdev->data_offset = base_info->data_offset;
+		sb_base_bdev->data_size = base_info->data_size;
+		sb_base_bdev->state = RAID_SB_BASE_BDEV_CONFIGURED;
+		sb_base_bdev->slot = sb_base_bdev - sb->base_bdevs;
+
+		raid_bdev_write_superblock(raid_bdev, raid_bdev_grow_base_bdev_write_sb_cb, ctx);
+		return;
+	}
+
+out:
+	raid_bdev_grow_base_bdev_done(ctx, status);
+}
+
+static int
+raid_bdev_grow_base_bdev_unquiesce(void *_ctx, int status)
+{
+	struct raid_bdev_grow_base_bdev_ctx *ctx = _ctx;
+	struct raid_bdev *raid_bdev = ctx->raid_bdev;
+
+	assert(spdk_get_thread() == spdk_thread_get_app_thread());
+
+	ctx->status = status;
+	return spdk_bdev_unquiesce(&raid_bdev->bdev, &g_raid_if,
+				   raid_bdev_grow_base_bdev_on_unquiesced, ctx);
+}
+
+static void
+raid_bdev_channels_grow_base_bdev_done(struct spdk_io_channel_iter *i, int status)
+{
+	struct raid_bdev_grow_base_bdev_ctx *ctx = spdk_io_channel_iter_get_ctx(i);
+
+	raid_bdev_grow_base_bdev_unquiesce(ctx, status);
+}
+
+static void
+raid_bdev_channel_grow_base_bdev(struct spdk_io_channel_iter *i)
+{
+	struct raid_bdev_grow_base_bdev_ctx *ctx = spdk_io_channel_iter_get_ctx(i);
+	struct spdk_io_channel *ch = spdk_io_channel_iter_get_channel(i);
+	struct raid_bdev_io_channel *raid_ch = spdk_io_channel_get_ctx(ch);
+	void *tmp;
+
+	SPDK_DEBUGLOG(bdev_raid, "slot: %u raid_ch: %p\n", ctx->slot, raid_ch);
+
+	/* Check if num_base_bdevs have been incremented */
+	if (raid_ch->num_channels != ctx->raid_bdev->num_base_bdevs) {
+		/* Reallocate base_channel array */
+		tmp = realloc(raid_ch->base_channel,
+			      ctx->raid_bdev->num_base_bdevs * sizeof(*raid_ch->base_channel));
+		if (!tmp) {
+			SPDK_ERRLOG("Unable to reallocate raid channel base_channel\n");
+			goto err;
+		}
+		memset(tmp + raid_ch->num_channels * sizeof(*raid_ch->base_channel), 0,
+		       sizeof(*raid_ch->base_channel));
+		raid_ch->base_channel = tmp;
+	}
+
+	/* Check for base_channel existence, it could have been removed by a remove operation */
+	if (raid_ch->base_channel[ctx->slot] == NULL) {
+		raid_ch->base_channel[ctx->slot] = spdk_bdev_get_io_channel(
+				ctx->raid_bdev->base_bdev_info[ctx->slot].desc);
+	}
+	if (!raid_ch->base_channel[ctx->slot]) {
+		SPDK_ERRLOG("Unable to create io channel for base bdev\n");
+		goto err;
+	}
+
+	/*
+	 * channel_grow_base_bdev must be called before to update raid_ch->num_channels, so that
+	 * the module can know the previous number of base bdevs
+	 */
+	if (ctx->raid_bdev->module->channel_grow_base_bdev(ctx->raid_bdev, raid_ch) == false) {
+		SPDK_ERRLOG("Unable to grow raid adding a base bdev to raid module channel\n");
+		goto err;
+	}
+
+	raid_ch->num_channels = ctx->raid_bdev->num_base_bdevs;
+
+	spdk_for_each_channel_continue(i, 0);
+
+	return;
+
+err:
+	spdk_for_each_channel_continue(i, -ENOMEM);
+}
+
+static void
+raid_bdev_grow_base_bdev_on_added(void *_ctx, int status)
+{
+	struct raid_bdev_grow_base_bdev_ctx *ctx = _ctx;
+	struct raid_bdev *raid_bdev = ctx->raid_bdev;
+
+	if (status != 0) {
+		raid_bdev_grow_base_bdev_unquiesce(ctx, status);
+		return;
+	}
+
+	spdk_for_each_channel(raid_bdev, raid_bdev_channel_grow_base_bdev, ctx,
+			      raid_bdev_channels_grow_base_bdev_done);
+}
+
+static int
+raid_bdev_grow_base_bdev_get_slot(struct raid_bdev *raid_bdev, uint8_t *slot)
+{
+	uint8_t num_base_bdevs = raid_bdev->num_base_bdevs;
+	struct raid_base_bdev_info *base_info = NULL;
+	void *tmp;
+	int i;
+
+	/* Check for free slot, because a previous remove operation could have created an hole */
+	for (i = 0; i < raid_bdev->num_base_bdevs; i++) {
+		base_info = &raid_bdev->base_bdev_info[i];
+		if (base_info->name == NULL) {
+			break;
+		}
+	}
+
+	if (base_info != NULL && base_info->remove_scheduled) {
+		SPDK_ERRLOG("A base bdev remove operation is in progress\n");
+		return -EBUSY;
+	}
+
+	/* If no hole was found, we have to increase the number of base bdevs */
+	if (i == raid_bdev->num_base_bdevs) {
+		num_base_bdevs++;
+
+		tmp = realloc(raid_bdev->base_bdev_info, num_base_bdevs * sizeof(*raid_bdev->base_bdev_info));
+		if (tmp == NULL) {
+			SPDK_ERRLOG("Unable able to reallocate base bdev info\n");
+			return -ENOMEM;
+		}
+		memset(tmp + raid_bdev->num_base_bdevs * sizeof(*raid_bdev->base_bdev_info), 0,
+		       sizeof(*raid_bdev->base_bdev_info));
+		raid_bdev->base_bdev_info = tmp;
+
+		/* Check on min_operational have already been done at raid creation */
+		raid_bdev->min_base_bdevs_operational = raid_bdev_module_get_min_operational(raid_bdev->bdev.name,
+							raid_bdev->module,
+							num_base_bdevs);
+
+		raid_bdev->num_base_bdevs = num_base_bdevs;
+	}
+
+	*slot = i;
+
+	return 0;
+}
+
+static void
+raid_bdev_grow_base_bdev_on_quiesced(void *_ctx, int status)
+{
+	struct raid_bdev_grow_base_bdev_ctx *ctx = _ctx;
+	struct raid_bdev *raid_bdev = ctx->raid_bdev;
+	struct raid_base_bdev_info *base_info;
+	int rc;
+
+	if (status != 0) {
+		SPDK_ERRLOG("Failed to quiesce raid bdev %s: %s\n",
+			    raid_bdev->bdev.name, spdk_strerror(-status));
+		raid_bdev_grow_base_bdev_done(ctx, status);
+		return;
+	}
+
+	rc = raid_bdev_grow_base_bdev_get_slot(ctx->raid_bdev, &ctx->slot);
+	if (rc != 0) {
+		goto err;
+	}
+
+	base_info = &raid_bdev->base_bdev_info[ctx->slot];
+
+	assert(base_info->is_configured == false);
+	assert(base_info->desc == NULL);
+
+	/* Add base bdev to raid */
+
+	base_info->name = strdup(ctx->base_bdev_name);
+	if (base_info->name == NULL) {
+		goto err;
+	}
+
+	base_info->raid_bdev = raid_bdev;
+
+	/* TODO add a parameter to the attach and grow functions to set this */
+	base_info->skip_rebuild = true;
+
+	rc = raid_bdev_configure_base_bdev(base_info, false, raid_bdev_grow_base_bdev_on_added, ctx);
+	if (rc != 0 && (rc != -ENODEV || raid_bdev->state != RAID_BDEV_STATE_CONFIGURING)) {
+		SPDK_ERRLOG("base bdev '%s' configure failed: %s\n", ctx->base_bdev_name, spdk_strerror(-rc));
+		free(base_info->name);
+		base_info->name = NULL;
+		goto err;
+	}
+
+	return;
+
+err:
+	ctx->status = rc;
+	spdk_bdev_unquiesce(&raid_bdev->bdev, &g_raid_if, raid_bdev_grow_base_bdev_on_unquiesced, ctx);
+}
+
+static int
+raid_bdev_grow_base_bdev_quiesce(struct raid_bdev_grow_base_bdev_ctx *ctx)
+{
+	struct raid_bdev *raid_bdev = ctx->raid_bdev;
+
+	assert(spdk_get_thread() == spdk_thread_get_app_thread());
+
+	return spdk_bdev_quiesce(&raid_bdev->bdev, &g_raid_if,
+				 raid_bdev_grow_base_bdev_on_quiesced, ctx);
+}
+
+/*
+ * brief:
+ * raid_bdev_grow_base_bdev add a base bdev to a raid bdev, growing the raid's size if needed
+ * params:
+ * raid_bdev - pointer to raid bdev
+ * base_bdev - pointer to base bdev
+ * returns:
+ * 0 - success
+ * non zero - failure
+ */
+int
+raid_bdev_grow_base_bdev(struct raid_bdev *raid_bdev, char *base_bdev_name,
+			 raid_bdev_destruct_cb cb_fn, void *cb_arg)
+{
+	struct raid_bdev_grow_base_bdev_ctx *ctx;
+	struct spdk_bdev *base_bdev;
+	struct raid_base_bdev_info *base_info;
+	int rc;
+
+	assert(raid_bdev != NULL);
+	assert(spdk_get_thread() == spdk_thread_get_app_thread());
+
+	/* Check if bdev is already a base bdev of this raid */
+	base_bdev = spdk_bdev_get_by_name(base_bdev_name);
+	base_info = raid_bdev_find_base_info_by_bdev(base_bdev);
+	if (base_info != NULL && base_info->raid_bdev == raid_bdev) {
+		SPDK_WARNLOG("bdev to grow '%s' already base bdev of raid %s\n", base_bdev_name,
+			     raid_bdev->bdev.name);
+		if (cb_fn != NULL) {
+			cb_fn(cb_arg, 0);
+		}
+		return 0;
+	}
+
+	if (raid_bdev->state != RAID_BDEV_STATE_ONLINE) {
+		SPDK_ERRLOG("raid bdev '%s' must be in online state to grow base bdev\n",
+			    raid_bdev->bdev.name);
+		return -EINVAL;
+	}
+
+	/* Check if grow operation is supported */
+	if (!raid_bdev->module->channel_grow_base_bdev) {
+		SPDK_ERRLOG("Raid level does not support growth adding a base bdev.\n");
+		return -EPERM;
+	}
+
+
+	if (raid_bdev->base_bdev_updating == true) {
+		SPDK_ERRLOG("Another operation is in progress.\n");
+		return -EBUSY;
+	}
+
+	ctx = calloc(1, sizeof(*ctx));
+	if (ctx == NULL) {
+		SPDK_ERRLOG("Unable to allocate memory for grow raid bdev context\n");
+		return -ENOMEM;
+	}
+
+	raid_bdev->base_bdev_updating = true;
+
+	ctx->raid_bdev = raid_bdev;
+	ctx->base_bdev_name = strdup(base_bdev_name);
+	if (ctx->base_bdev_name == NULL) {
+		SPDK_ERRLOG("Unable to allocate memory for grow raid bdev base_bdev_name\n");
+		raid_bdev->base_bdev_updating = false;
+		free(ctx);
+		return -ENOMEM;
+	}
+
+	ctx->cb_fn = cb_fn;
+	ctx->cb_arg = cb_arg;
+
+	rc = raid_bdev_grow_base_bdev_quiesce(ctx);
+	if (rc != 0) {
+		raid_bdev->base_bdev_updating = false;
+		free(ctx->base_bdev_name);
+		free(ctx);
 	}
 
 	return rc;

--- a/module/bdev/raid/bdev_raid.c
+++ b/module/bdev/raid/bdev_raid.c
@@ -156,6 +156,30 @@ raid_bdev_channel_get_base_info(struct raid_bdev_io_channel *raid_ch, struct spd
 	return NULL;
 }
 
+static uint8_t
+raid_bdev_module_get_min_operational(const char *name, struct raid_bdev_module *module,
+				     uint8_t num_base_bdevs)
+{
+	switch (module->base_bdevs_constraint.type) {
+	case CONSTRAINT_MAX_BASE_BDEVS_REMOVED:
+		return num_base_bdevs - module->base_bdevs_constraint.value;
+	case CONSTRAINT_MIN_BASE_BDEVS_OPERATIONAL:
+		return module->base_bdevs_constraint.value;
+	case CONSTRAINT_UNSET:
+		if (module->base_bdevs_constraint.value != 0) {
+			SPDK_ERRLOG("Unexpected constraint value '%u' provided for raid bdev '%s'.\n",
+				    (uint8_t)module->base_bdevs_constraint.value, name);
+			return 0;
+		}
+		return num_base_bdevs;
+	default:
+		SPDK_ERRLOG("Unrecognised constraint type '%u' in module for raid level '%s'.\n",
+			    (uint8_t)module->base_bdevs_constraint.type,
+			    raid_bdev_level_to_str(module->level));
+		return 0;
+	}
+}
+
 /* Function declarations */
 static void	raid_bdev_examine(struct spdk_bdev *bdev);
 static int	raid_bdev_init(void);
@@ -1490,27 +1514,7 @@ _raid_bdev_create(const char *name, uint32_t strip_size, uint8_t num_base_bdevs,
 		return -EINVAL;
 	}
 
-	switch (module->base_bdevs_constraint.type) {
-	case CONSTRAINT_MAX_BASE_BDEVS_REMOVED:
-		min_operational = num_base_bdevs - module->base_bdevs_constraint.value;
-		break;
-	case CONSTRAINT_MIN_BASE_BDEVS_OPERATIONAL:
-		min_operational = module->base_bdevs_constraint.value;
-		break;
-	case CONSTRAINT_UNSET:
-		if (module->base_bdevs_constraint.value != 0) {
-			SPDK_ERRLOG("Unexpected constraint value '%u' provided for raid bdev '%s'.\n",
-				    (uint8_t)module->base_bdevs_constraint.value, name);
-			return -EINVAL;
-		}
-		min_operational = num_base_bdevs;
-		break;
-	default:
-		SPDK_ERRLOG("Unrecognised constraint type '%u' in module for raid level '%s'.\n",
-			    (uint8_t)module->base_bdevs_constraint.type,
-			    raid_bdev_level_to_str(module->level));
-		return -EINVAL;
-	};
+	min_operational = raid_bdev_module_get_min_operational(name, module, num_base_bdevs);
 
 	if (min_operational == 0 || min_operational > num_base_bdevs) {
 		SPDK_ERRLOG("Wrong constraint value for raid level '%s'.\n",

--- a/module/bdev/raid/bdev_raid.h
+++ b/module/bdev/raid/bdev_raid.h
@@ -470,7 +470,7 @@ enum raid_bdev_sb_base_bdev_state {
 	RAID_SB_BASE_BDEV_MISSING	= 0,
 	RAID_SB_BASE_BDEV_CONFIGURED	= 1,
 	RAID_SB_BASE_BDEV_FAILED	= 2,
-	RAID_SB_BASE_BDEV_SPARE		= 3,
+	RAID_SB_BASE_BDEV_REMOVED	= 3,
 };
 
 struct raid_bdev_sb_base_bdev {

--- a/module/bdev/raid/bdev_raid_rpc.c
+++ b/module/bdev/raid/bdev_raid_rpc.c
@@ -635,3 +635,139 @@ rpc_bdev_raid_set_options(struct spdk_jsonrpc_request *request, const struct spd
 }
 SPDK_RPC_REGISTER("bdev_raid_set_options", rpc_bdev_raid_set_options,
 		  SPDK_RPC_STARTUP | SPDK_RPC_RUNTIME)
+
+/*
+ * Input structure for RPC rpc_bdev_raid_grow_base_bdev
+ */
+struct rpc_bdev_raid_grow_base_bdev {
+	/* Raid bdev name */
+	char *raid_bdev_name;
+
+	/* Base bdev name */
+	char *base_bdev_name;
+};
+
+/*
+ * brief:
+ * free_rpc_bdev_raid_grow_base_bdev frees RPC bdev_raid_grow_base_bdev related parameters
+ * params:
+ * req - pointer to RPC request
+ * returns:
+ * none
+ */
+static void
+free_rpc_bdev_raid_grow_base_bdev(struct rpc_bdev_raid_grow_base_bdev *req)
+{
+	free(req->raid_bdev_name);
+	free(req->base_bdev_name);
+}
+
+/*
+ * Decoder object for RPC bdev_raid_grow_base_bdev
+ */
+static const struct spdk_json_object_decoder rpc_bdev_raid_grow_base_bdev_decoders[] = {
+	{"raid_name", offsetof(struct rpc_bdev_raid_grow_base_bdev, raid_bdev_name), spdk_json_decode_string},
+	{"base_name", offsetof(struct rpc_bdev_raid_grow_base_bdev, base_bdev_name), spdk_json_decode_string},
+};
+
+struct rpc_bdev_raid_grow_base_bdev_ctx {
+	struct rpc_bdev_raid_grow_base_bdev req;
+	struct spdk_jsonrpc_request *request;
+};
+
+/*
+ * brief:
+ * params:
+ * cb_arg - pointer to the callback context.
+ * rc - return code of the growing a base bdev.
+ * returns:
+ * none
+ */
+static void
+bdev_raid_grow_base_bdev_done(void *cb_arg, int rc)
+{
+	struct rpc_bdev_raid_grow_base_bdev_ctx *ctx = cb_arg;
+	struct spdk_jsonrpc_request *request = ctx->request;
+
+	if (rc != 0) {
+		SPDK_ERRLOG("Failed to grow raid %s adding base bdev %s (%d): %s\n",
+			    ctx->req.raid_bdev_name, ctx->req.base_bdev_name, rc, spdk_strerror(-rc));
+		spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_INTERNAL_ERROR,
+						 spdk_strerror(-rc));
+		goto exit;
+	}
+
+	spdk_jsonrpc_send_bool_response(request, true);
+exit:
+	free_rpc_bdev_raid_grow_base_bdev(&ctx->req);
+	free(ctx);
+}
+
+/*
+ * brief:
+ * bdev_raid_grow_base_bdev is the RPC to add a base bdev to a raid bdev, growing the raid's size
+ * if there isn't an empty base bdev slot. It takes raid bdev name and base bdev name as input.
+ * params:
+ * request - pointer to json rpc request
+ * params - pointer to request parameters
+ * returns:
+ * none
+ */
+static void
+rpc_bdev_raid_grow_base_bdev(struct spdk_jsonrpc_request *request,
+			     const struct spdk_json_val *params)
+{
+	struct rpc_bdev_raid_grow_base_bdev_ctx *ctx;
+	struct raid_bdev *raid_bdev;
+	struct spdk_bdev *base_bdev;
+	int rc;
+
+	ctx = calloc(1, sizeof(*ctx));
+	if (!ctx) {
+		spdk_jsonrpc_send_error_response(request, -ENOMEM, spdk_strerror(ENOMEM));
+		return;
+	}
+
+	if (spdk_json_decode_object(params, rpc_bdev_raid_grow_base_bdev_decoders,
+				    SPDK_COUNTOF(rpc_bdev_raid_grow_base_bdev_decoders),
+				    &ctx->req)) {
+		spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_PARSE_ERROR,
+						 "spdk_json_decode_object failed");
+		goto cleanup;
+	}
+
+	raid_bdev = raid_bdev_find_by_name(ctx->req.raid_bdev_name);
+	if (raid_bdev == NULL) {
+		spdk_jsonrpc_send_error_response_fmt(request, -ENODEV,
+						     "raid bdev %s not found",
+						     ctx->req.raid_bdev_name);
+		goto cleanup;
+	}
+
+	base_bdev = spdk_bdev_get_by_name(ctx->req.base_bdev_name);
+	if (base_bdev == NULL) {
+		spdk_jsonrpc_send_error_response_fmt(request, -ENODEV,
+						     "base bdev %s not found",
+						     ctx->req.base_bdev_name);
+		goto cleanup;
+	}
+
+	ctx->request = request;
+
+	rc = raid_bdev_grow_base_bdev(raid_bdev, ctx->req.base_bdev_name, bdev_raid_grow_base_bdev_done,
+				      ctx);
+	if (rc != 0) {
+		spdk_jsonrpc_send_error_response_fmt(request, rc,
+						     "Failed to grow raid %s adding base bdev %s: %s",
+						     ctx->req.raid_bdev_name, ctx->req.base_bdev_name,
+						     spdk_strerror(-rc));
+		goto cleanup;
+	}
+
+	return;
+
+cleanup:
+	free_rpc_bdev_raid_grow_base_bdev(&ctx->req);
+	free(ctx);
+}
+SPDK_RPC_REGISTER("bdev_raid_grow_base_bdev", rpc_bdev_raid_grow_base_bdev, SPDK_RPC_RUNTIME)

--- a/module/bdev/raid/raid1.c
+++ b/module/bdev/raid/raid1.c
@@ -218,6 +218,18 @@ raid1_flush_bdev_io_completion(struct spdk_bdev_io *bdev_io, bool success, void 
 				   SPDK_BDEV_IO_STATUS_FAILED);
 }
 
+static void
+raid1_unmap_bdev_io_completion(struct spdk_bdev_io *bdev_io, bool success, void *cb_arg)
+{
+	struct raid_bdev_io *raid_io = cb_arg;
+
+	spdk_bdev_free_io(bdev_io);
+
+	raid_bdev_io_complete_part(raid_io, 1, success ?
+				   SPDK_BDEV_IO_STATUS_SUCCESS :
+				   SPDK_BDEV_IO_STATUS_FAILED);
+}
+
 static void raid1_submit_rw_request(struct raid_bdev_io *raid_io);
 
 static void
@@ -372,7 +384,7 @@ _raid1_submit_null_payload_request(void *_raid_io)
 }
 
 static int
-raid1_submit_flush_request(struct raid_bdev_io *raid_io)
+submit_null_payload_request(struct raid_bdev_io *raid_io)
 {
 	struct raid_bdev *raid_bdev = raid_io->raid_bdev;
 	struct spdk_bdev_io *bdev_io = spdk_bdev_io_from_ctx(raid_io);
@@ -400,8 +412,21 @@ raid1_submit_flush_request(struct raid_bdev_io *raid_io)
 			continue;
 		}
 
-		ret = raid_bdev_flush_blocks(base_info, base_ch, pd_lba, pd_blocks,
-					     raid1_flush_bdev_io_completion, raid_io);
+		switch (bdev_io->type) {
+		case SPDK_BDEV_IO_TYPE_UNMAP:
+			ret = raid_bdev_unmap_blocks(base_info, base_ch,
+						     pd_lba, pd_blocks,
+						     raid1_unmap_bdev_io_completion, raid_io);
+			break;
+		case SPDK_BDEV_IO_TYPE_FLUSH:
+			ret = raid_bdev_flush_blocks(base_info, base_ch,
+						     pd_lba, pd_blocks,
+						     raid1_flush_bdev_io_completion, raid_io);
+			break;
+		default:
+			SPDK_ERRLOG("submit request, invalid io type with null payload %u\n", bdev_io->type);
+			ret = -EIO;
+		}
 		if (spdk_unlikely(ret != 0)) {
 			if (spdk_unlikely(ret == -ENOMEM)) {
 				raid_bdev_queue_io_wait(raid_io, spdk_bdev_desc_get_bdev(base_info->desc),
@@ -429,17 +454,7 @@ raid1_submit_flush_request(struct raid_bdev_io *raid_io)
 static void
 raid1_submit_null_payload_request(struct raid_bdev_io *raid_io)
 {
-	struct spdk_bdev_io *bdev_io = spdk_bdev_io_from_ctx(raid_io);
-	int ret;
-
-	switch (bdev_io->type) {
-	case SPDK_BDEV_IO_TYPE_FLUSH:
-		ret = raid1_submit_flush_request(raid_io);
-		break;
-	default:
-		ret = -EINVAL;
-		break;
-	}
+	int ret = submit_null_payload_request(raid_io);
 
 	if (spdk_unlikely(ret != 0)) {
 		raid_bdev_io_complete(raid_io, SPDK_BDEV_IO_STATUS_FAILED);

--- a/module/bdev/raid/raid1.c
+++ b/module/bdev/raid/raid1.c
@@ -502,7 +502,7 @@ raid1_submit_process_request(struct raid_bdev_process_request *process_req,
 
 static struct raid_bdev_module g_raid1_module = {
 	.level = RAID1,
-	.base_bdevs_min = 2,
+	.base_bdevs_min = 1,
 	.base_bdevs_constraint = {CONSTRAINT_MIN_BASE_BDEVS_OPERATIONAL, 1},
 	.memory_domains_supported = true,
 	.start = raid1_start,

--- a/module/bdev/raid/raid1.c
+++ b/module/bdev/raid/raid1.c
@@ -15,7 +15,7 @@ struct raid1_info {
 
 struct raid1_io_channel {
 	/* Array of per-base_bdev counters of outstanding read blocks on this channel */
-	uint64_t read_blocks_outstanding[0];
+	uint64_t *read_blocks_outstanding;
 };
 
 static void
@@ -352,12 +352,27 @@ raid1_submit_rw_request(struct raid_bdev_io *raid_io)
 static void
 raid1_ioch_destroy(void *io_device, void *ctx_buf)
 {
+	struct raid1_io_channel *r1ch = ctx_buf;
+
+	free(r1ch->read_blocks_outstanding);
 }
 
 static int
 raid1_ioch_create(void *io_device, void *ctx_buf)
 {
-	return 0;
+	struct raid1_io_channel *r1ch = ctx_buf;
+	struct raid1_info *r1info = io_device;
+	struct raid_bdev *raid_bdev = r1info->raid_bdev;
+	int ret = 0;
+
+	r1ch->read_blocks_outstanding = calloc(raid_bdev->num_base_bdevs,
+					       sizeof(*r1ch->read_blocks_outstanding));
+	if (!r1ch->read_blocks_outstanding) {
+		SPDK_ERRLOG("Failed to initialize io channel\n");
+		ret = -ENOMEM;
+	}
+
+	return ret;
 }
 
 static void
@@ -398,8 +413,7 @@ raid1_start(struct raid_bdev *raid_bdev)
 
 	snprintf(name, sizeof(name), "raid1_%s", raid_bdev->bdev.name);
 	spdk_io_device_register(r1info, raid1_ioch_create, raid1_ioch_destroy,
-				sizeof(struct raid1_io_channel) + raid_bdev->num_base_bdevs * sizeof(uint64_t),
-				name);
+				sizeof(struct raid1_io_channel), name);
 
 	return 0;
 }
@@ -500,6 +514,28 @@ raid1_submit_process_request(struct raid_bdev_process_request *process_req,
 	}
 }
 
+static bool
+channel_grow_base_bdev(struct raid_bdev *raid_bdev, struct raid_bdev_io_channel *raid_ch)
+{
+	struct raid1_io_channel *raid1_ch = raid_bdev_channel_get_module_ctx(raid_ch);
+	uint8_t raid_ch_num_channels = raid_bdev_channel_get_num_channels(raid_ch);
+	void *tmp;
+
+	if (raid_ch_num_channels != raid_bdev->num_base_bdevs) {
+		tmp = realloc(raid1_ch->read_blocks_outstanding,
+			      raid_bdev->num_base_bdevs * sizeof(*raid1_ch->read_blocks_outstanding));
+		if (!tmp) {
+			SPDK_ERRLOG("Unable to reallocate raid1 channel base_bdev_modes_read_bw\n");
+			return false;
+		}
+		memset(tmp + raid_ch_num_channels * sizeof(*raid1_ch->read_blocks_outstanding), 0,
+		       sizeof(*raid1_ch->read_blocks_outstanding));
+		raid1_ch->read_blocks_outstanding = tmp;
+	}
+
+	return true;
+}
+
 static struct raid_bdev_module g_raid1_module = {
 	.level = RAID1,
 	.base_bdevs_min = 1,
@@ -510,6 +546,7 @@ static struct raid_bdev_module g_raid1_module = {
 	.submit_rw_request = raid1_submit_rw_request,
 	.get_io_channel = raid1_get_io_channel,
 	.submit_process_request = raid1_submit_process_request,
+	.channel_grow_base_bdev = channel_grow_base_bdev,
 };
 RAID_MODULE_REGISTER(&g_raid1_module)
 

--- a/module/bdev/raid/raid1.c
+++ b/module/bdev/raid/raid1.c
@@ -206,6 +206,18 @@ raid1_read_bdev_io_completion(struct spdk_bdev_io *bdev_io, bool success, void *
 	raid_bdev_io_complete(raid_io, SPDK_BDEV_IO_STATUS_SUCCESS);
 }
 
+static void
+raid1_flush_bdev_io_completion(struct spdk_bdev_io *bdev_io, bool success, void *cb_arg)
+{
+	struct raid_bdev_io *raid_io = cb_arg;
+
+	spdk_bdev_free_io(bdev_io);
+
+	raid_bdev_io_complete_part(raid_io, 1, success ?
+				   SPDK_BDEV_IO_STATUS_SUCCESS :
+				   SPDK_BDEV_IO_STATUS_FAILED);
+}
+
 static void raid1_submit_rw_request(struct raid_bdev_io *raid_io);
 
 static void
@@ -338,6 +350,91 @@ raid1_submit_rw_request(struct raid_bdev_io *raid_io)
 		break;
 	case SPDK_BDEV_IO_TYPE_WRITE:
 		ret = raid1_submit_write_request(raid_io);
+		break;
+	default:
+		ret = -EINVAL;
+		break;
+	}
+
+	if (spdk_unlikely(ret != 0)) {
+		raid_bdev_io_complete(raid_io, SPDK_BDEV_IO_STATUS_FAILED);
+	}
+}
+
+static void raid1_submit_null_payload_request(struct raid_bdev_io *raid_io);
+
+static void
+_raid1_submit_null_payload_request(void *_raid_io)
+{
+	struct raid_bdev_io *raid_io = _raid_io;
+
+	raid1_submit_null_payload_request(raid_io);
+}
+
+static int
+raid1_submit_flush_request(struct raid_bdev_io *raid_io)
+{
+	struct raid_bdev *raid_bdev = raid_io->raid_bdev;
+	struct spdk_bdev_io *bdev_io = spdk_bdev_io_from_ctx(raid_io);
+	struct raid_base_bdev_info *base_info;
+	struct spdk_io_channel *base_ch;
+	uint64_t pd_lba, pd_blocks;
+	uint8_t idx;
+	uint64_t base_bdev_io_not_submitted;
+	int ret = 0;
+
+	pd_lba = bdev_io->u.bdev.offset_blocks;
+	pd_blocks = bdev_io->u.bdev.num_blocks;
+
+	if (raid_io->base_bdev_io_submitted == 0) {
+		raid_io->base_bdev_io_remaining = raid_bdev->num_base_bdevs;
+	}
+
+	for (idx = raid_io->base_bdev_io_submitted; idx < raid_bdev->num_base_bdevs; idx++) {
+		base_info = &raid_bdev->base_bdev_info[idx];
+		base_ch = raid_bdev_channel_get_base_channel(raid_io->raid_ch, idx);
+
+		if (base_ch == NULL) {
+			raid_io->base_bdev_io_submitted++;
+			raid_bdev_io_complete_part(raid_io, 1, SPDK_BDEV_IO_STATUS_SUCCESS);
+			continue;
+		}
+
+		ret = raid_bdev_flush_blocks(base_info, base_ch, pd_lba, pd_blocks,
+					     raid1_flush_bdev_io_completion, raid_io);
+		if (spdk_unlikely(ret != 0)) {
+			if (spdk_unlikely(ret == -ENOMEM)) {
+				raid_bdev_queue_io_wait(raid_io, spdk_bdev_desc_get_bdev(base_info->desc),
+							base_ch, _raid1_submit_null_payload_request);
+				return 0;
+			}
+
+			base_bdev_io_not_submitted = raid_bdev->num_base_bdevs -
+						     raid_io->base_bdev_io_submitted;
+			raid_bdev_io_complete_part(raid_io, base_bdev_io_not_submitted,
+						   SPDK_BDEV_IO_STATUS_FAILED);
+			return 0;
+		}
+
+		raid_io->base_bdev_io_submitted++;
+	}
+
+	if (raid_io->base_bdev_io_submitted == 0) {
+		ret = -ENODEV;
+	}
+
+	return ret;
+}
+
+static void
+raid1_submit_null_payload_request(struct raid_bdev_io *raid_io)
+{
+	struct spdk_bdev_io *bdev_io = spdk_bdev_io_from_ctx(raid_io);
+	int ret;
+
+	switch (bdev_io->type) {
+	case SPDK_BDEV_IO_TYPE_FLUSH:
+		ret = raid1_submit_flush_request(raid_io);
 		break;
 	default:
 		ret = -EINVAL;
@@ -544,6 +641,7 @@ static struct raid_bdev_module g_raid1_module = {
 	.start = raid1_start,
 	.stop = raid1_stop,
 	.submit_rw_request = raid1_submit_rw_request,
+	.submit_null_payload_request = raid1_submit_null_payload_request,
 	.get_io_channel = raid1_get_io_channel,
 	.submit_process_request = raid1_submit_process_request,
 	.channel_grow_base_bdev = channel_grow_base_bdev,

--- a/python/spdk/rpc/bdev.py
+++ b/python/spdk/rpc/bdev.py
@@ -487,6 +487,22 @@ def bdev_raid_remove_base_bdev(client, name):
     return client.call('bdev_raid_remove_base_bdev', params)
 
 
+def bdev_raid_grow_base_bdev(client, raid_name, base_name):
+    """Add a base bdev to a raid bdev, growing the raid's size if there
+    isn't an empty base bdev slot
+
+    Args:
+        raid_name: raid bdev name
+        base_name: base bdev name
+
+    Returns:
+        None
+    """
+    params = {'raid_name': raid_name, 'base_name': base_name}
+
+    return client.call('bdev_raid_grow_base_bdev', params)
+
+
 def bdev_aio_create(client, filename, name, block_size=None, readonly=False, fallocate=False):
     """Construct a Linux AIO block device.
 

--- a/python/spdk/rpc/lvol.py
+++ b/python/spdk/rpc/lvol.py
@@ -278,6 +278,25 @@ def bdev_lvol_set_parent_bdev(client, lvol_name, esnap_name):
     return client.call('bdev_lvol_set_parent_bdev', params)
 
 
+def bdev_lvol_get_fragmap(client, name, offset=0, size=0):
+    """Get a fragmap for a specific segment of a logical volume using the provided offset and size
+
+    Args:
+        name: lvol bdev name
+        offset: offset in bytes of the specific segment of the logical volume
+        size: size in bytes of the specific segment of the logical volume
+    """
+    params = {
+        'name': name,
+    }
+    if offset:
+        params['offset'] = offset
+    if size:
+        params['size'] = size
+
+    return client.call('bdev_lvol_get_fragmap', params)
+
+
 def bdev_lvol_delete_lvstore(client, uuid=None, lvs_name=None):
     """Destroy a logical volume store.
 

--- a/python/spdk/rpc/lvol.py
+++ b/python/spdk/rpc/lvol.py
@@ -89,12 +89,13 @@ def bdev_lvol_create(client, lvol_name, size_in_mib, thin_provision=False, uuid=
     return client.call('bdev_lvol_create', params)
 
 
-def bdev_lvol_snapshot(client, lvol_name, snapshot_name):
+def bdev_lvol_snapshot(client, lvol_name, snapshot_name, xattrs=None):
     """Capture a snapshot of the current state of a logical volume.
 
     Args:
         lvol_name: logical volume to create a snapshot from
         snapshot_name: name for the newly created snapshot
+        xattrs: a map of xattr keys to values (optional)
 
     Returns:
         Name of created logical volume snapshot.
@@ -103,6 +104,9 @@ def bdev_lvol_snapshot(client, lvol_name, snapshot_name):
         'lvol_name': lvol_name,
         'snapshot_name': snapshot_name
     }
+    if xattrs is not None:
+        params['xattrs'] = xattrs
+
     return client.call('bdev_lvol_snapshot', params)
 
 

--- a/python/spdk/rpc/lvol.py
+++ b/python/spdk/rpc/lvol.py
@@ -161,6 +161,22 @@ def bdev_lvol_rename(client, old_name, new_name):
     return client.call('bdev_lvol_rename', params)
 
 
+def bdev_lvol_set_xattr(client, name, xattr_name, xattr_value):
+    """Set extended attribute on a logical volume.
+
+    Args:
+        name: name of logical volume
+        xattr_name: name of extended attribute
+        xattr_value: value of extended attribute
+    """
+    params = {
+        'name': name,
+        'xattr_name': xattr_name,
+        'xattr_value': xattr_value,
+    }
+    return client.call('bdev_lvol_set_xattr', params)
+
+
 def bdev_lvol_resize(client, name, size_in_mib):
     """Resize a logical volume.
 

--- a/python/spdk/rpc/lvol.py
+++ b/python/spdk/rpc/lvol.py
@@ -177,6 +177,20 @@ def bdev_lvol_set_xattr(client, name, xattr_name, xattr_value):
     return client.call('bdev_lvol_set_xattr', params)
 
 
+def bdev_lvol_get_xattr(client, name, xattr_name):
+    """Get extended attribute on a logical volume.
+
+    Args:
+        name: name of logical volume
+        xattr_name: name of extended attribute
+    """
+    params = {
+        'name': name,
+        'xattr_name': xattr_name,
+    }
+    return client.call('bdev_lvol_get_xattr', params)
+
+
 def bdev_lvol_resize(client, name, size_in_mib):
     """Resize a logical volume.
 

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -2173,6 +2173,18 @@ Format: 'user:u1 secret:s1 muser:mu1 msecret:ms1,user:u2 secret:s2 muser:mu2 mse
     p.add_argument('esnap_name', help='external snapshot name')
     p.set_defaults(func=bdev_lvol_set_parent_bdev)
 
+    def bdev_lvol_get_fragmap(args):
+        print_json(rpc.lvol.bdev_lvol_get_fragmap(args.client,
+                                                  name=args.name,
+                                                  offset=args.offset,
+                                                  size=args.size))
+    p = subparsers.add_parser('bdev_lvol_get_fragmap', help="""Get a fragmap for a specific segment of a logical volume using
+                                                            the provided offset and size.""")
+    p.add_argument('name', help='lvol bdev name')
+    p.add_argument('--offset', help='offset in bytes of the specific segment of the logical volume', type=int, required=False)
+    p.add_argument('--size', help='size in bytes of the specific segment of the logical volume', type=int, required=False)
+    p.set_defaults(func=bdev_lvol_get_fragmap)
+
     def bdev_lvol_delete_lvstore(args):
         rpc.lvol.bdev_lvol_delete_lvstore(args.client,
                                           uuid=args.uuid,

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -2091,6 +2091,18 @@ Format: 'user:u1 secret:s1 muser:mu1 msecret:ms1,user:u2 secret:s2 muser:mu2 mse
     p.add_argument('new_name', help='new lvol name')
     p.set_defaults(func=bdev_lvol_rename)
 
+    def bdev_lvol_set_xattr(args):
+        rpc.lvol.bdev_lvol_set_xattr(args.client,
+                                     name=args.name,
+                                     xattr_name=args.xattr_name,
+                                     xattr_value=args.xattr_value)
+
+    p = subparsers.add_parser('bdev_lvol_set_xattr', help='Set xattr for lvol bdev')
+    p.add_argument('name', help='lvol bdev name')
+    p.add_argument('xattr_name', help='xattr name')
+    p.add_argument('xattr_value', help='xattr value')
+    p.set_defaults(func=bdev_lvol_set_xattr)
+
     def bdev_lvol_inflate(args):
         rpc.lvol.bdev_lvol_inflate(args.client,
                                    name=args.name)

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -2272,6 +2272,16 @@ Format: 'user:u1 secret:s1 muser:mu1 msecret:ms1,user:u2 secret:s2 muser:mu2 mse
     p.add_argument('name', help='base bdev name')
     p.set_defaults(func=bdev_raid_remove_base_bdev)
 
+    def bdev_raid_grow_base_bdev(args):
+        rpc.bdev.bdev_raid_grow_base_bdev(args.client,
+                                          raid_name=args.raid_name,
+                                          base_name=args.base_name)
+    p = subparsers.add_parser('bdev_raid_grow_base_bdev', help="""Add a base bdev to a raid bdev,
+                              growing the raid\'s size if there isn't an empty base bdev slot""")
+    p.add_argument('raid_name', help='raid bdev name')
+    p.add_argument('base_name', help='base bdev name')
+    p.set_defaults(func=bdev_raid_grow_base_bdev)
+
     # split
     def bdev_split_create(args):
         print_array(rpc.bdev.bdev_split_create(args.client,

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -2049,13 +2049,24 @@ Format: 'user:u1 secret:s1 muser:mu1 msecret:ms1,user:u2 secret:s2 muser:mu2 mse
     p.set_defaults(func=bdev_lvol_create)
 
     def bdev_lvol_snapshot(args):
+        xattrs = None
+        if args.xattr:
+            xattrs = {}
+            for entry in args.xattr:
+                parts = entry.split('=', 1)
+                if len(parts) != 2:
+                    raise Exception('--xattr %s not in key=value format' % entry)
+                xattrs[parts[0]] = parts[1]
         print_json(rpc.lvol.bdev_lvol_snapshot(args.client,
                                                lvol_name=args.lvol_name,
-                                               snapshot_name=args.snapshot_name))
+                                               snapshot_name=args.snapshot_name,
+                                               xattrs=xattrs))
 
     p = subparsers.add_parser('bdev_lvol_snapshot', help='Create a snapshot of an lvol bdev')
     p.add_argument('lvol_name', help='lvol bdev name')
     p.add_argument('snapshot_name', help='lvol snapshot name')
+    p.add_argument('--xattr', action='append', metavar='key=value',
+                   help="adds a key=value xattr to the snapshot")
     p.set_defaults(func=bdev_lvol_snapshot)
 
     def bdev_lvol_clone(args):

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -2103,6 +2103,16 @@ Format: 'user:u1 secret:s1 muser:mu1 msecret:ms1,user:u2 secret:s2 muser:mu2 mse
     p.add_argument('xattr_value', help='xattr value')
     p.set_defaults(func=bdev_lvol_set_xattr)
 
+    def bdev_lvol_get_xattr(args):
+        print_dict(rpc.lvol.bdev_lvol_get_xattr(args.client,
+                                                name=args.name,
+                                                xattr_name=args.xattr_name))
+
+    p = subparsers.add_parser('bdev_lvol_get_xattr', help='Get xattr for lvol bdev')
+    p.add_argument('name', help='lvol bdev name')
+    p.add_argument('xattr_name', help='xattr name')
+    p.set_defaults(func=bdev_lvol_get_xattr)
+
     def bdev_lvol_inflate(args):
         rpc.lvol.bdev_lvol_inflate(args.client,
                                    name=args.name)

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -18,7 +18,7 @@ source "$rootdir/scripts/common.sh"
 
 function usage() {
 	if [[ $os == Linux ]]; then
-		options="[config|reset|status|cleanup|interactive|help]"
+		options="[config|reset|status|disk-status|disk-driver|bind|unbind|cleanup|interactive|help]"
 	else
 		options="[config|reset|interactive|help]"
 	fi
@@ -43,6 +43,10 @@ function usage() {
 	echo "                  Hugepage memory size will remain unchanged."
 	if [[ $os == Linux ]]; then
 		echo "status            Print status of all SPDK-compatible devices on the system."
+		echo "disk-status       Print status of a specific SPDK-compatible device on the system."
+		echo "disk-driver       Print driver name associated with a given PCI device's BDF address."
+		echo "bind              Bind a PCI device to a specific driver."
+		echo "unbind            Unbind a PCI device from its current driver and rebind it to the original driver."
 	fi
 	echo "interactive       Executes script in interactive mode."
 	echo "help              Print this help message."
@@ -736,6 +740,60 @@ function status_linux() {
 	done
 }
 
+function disk_status_linux() {
+	local target_bdf="$1"
+
+	if [[ -z $target_bdf ]]; then
+		echo "No BDF specified" >&2
+		return 1
+	fi
+
+	sorted_bdfs=($(printf '%s\n' "${!all_devices_d[@]}" | sort))
+
+	for bdf in "${sorted_bdfs[@]}"; do
+		if [ "$bdf" = "$target_bdf" ]; then
+			driver=${drivers_d["$bdf"]}
+			if [ "$numa_nodes" = "0" ]; then
+				node="-"
+			else
+				node=$(cat /sys/bus/pci/devices/$bdf/numa_node)
+				if ((node == -1)); then
+					node=unknown
+				fi
+			fi
+			if [ "$driver" = "nvme" ] && [ -d /sys/bus/pci/devices/$bdf/nvme ]; then
+				name=$(ls /sys/bus/pci/devices/$bdf/nvme)
+			else
+				name="-"
+			fi
+
+			if [[ -n ${nvme_d["$bdf"]} || -n ${virtio_d["$bdf"]} ]]; then
+				blknames=($(get_block_dev_from_bdf "$bdf"))
+			else
+				blknames=("-")
+			fi
+
+			desc=""
+			desc=${desc:-${nvme_d["$bdf"]:+NVMe}}
+			desc=${desc:-${ioat_d["$bdf"]:+I/OAT}}
+			desc=${desc:-${dsa_d["$bdf"]:+DSA}}
+			desc=${desc:-${iaa_d["$bdf"]:+IAA}}
+			desc=${desc:-${virtio_d["$bdf"]:+virtio}}
+			desc=${desc:-${vmd_d["$bdf"]:+VMD}}
+
+			local json_string="{\"bdf\":\"$bdf\", \
+				\"type\":\"$desc\", \
+				\"driver\":\"${driver:--}\", \
+				\"vendor\":\"${pci_ids_vendor["$bdf"]#0x}\", \
+				\"numa\":\"$node\", \
+				\"device\":\"${name:-}\", \
+				\"block_devices\":\"${blknames[*]:--}\"}"
+			formatted=$(echo "$json_string" | jq -c '.')
+			echo "$formatted"
+		fi
+	done
+}
+
 function status_freebsd() {
 	local pci
 
@@ -846,6 +904,61 @@ function set_hp() {
 	NRHUGE=${NRHUGE:-$(((HUGEMEM + HUGEPGSZ_MB - 1) / HUGEPGSZ_MB))}
 }
 
+function bind_linux() {
+	local driver_name=${DRIVER_OVERRIDE}
+
+	if [[ -z $driver_name ]]; then
+		echo "No driver specified, aborting"
+		return 1
+	fi
+
+	for bdf in "${!all_devices_d[@]}"; do
+		if ((all_devices_d["$bdf"] == 0)); then
+			if [[ -n ${nvme_d["$bdf"]} ]]; then
+				# Some nvme controllers may take significant amount of time while being
+				# unbound from the driver. Put that task into background to speed up the
+				# whole process. Currently this is done only for the devices bound to the
+				# nvme driver as other, i.e., ioatdma's, trigger a kernel BUG when being
+				# unbound in parallel. See https://bugzilla.kernel.org/show_bug.cgi?id=209041.
+				linux_bind_driver "$bdf" "$driver_name" &
+			else
+				linux_bind_driver "$bdf" "$driver_name"
+			fi
+		fi
+	done
+	wait
+
+	echo "1" > "/sys/bus/pci/rescan"
+}
+
+function unbind_linux() {
+	bdf=$1
+	if [[ -z $bdf ]]; then
+		echo "No BDF specified, aborting"
+		return 1
+	fi
+
+	driver=$(collect_driver "$bdf")
+	if [[ -n $driver ]] && ! check_for_driver "$driver"; then
+		linux_bind_driver "$bdf" "$driver"
+	else
+		linux_unbind_driver "$bdf"
+	fi
+
+	echo "1" > "/sys/bus/pci/rescan"
+}
+
+function disk_driver_linux() {
+	bdf=$1
+	if [[ -z $bdf ]]; then
+		echo "No BDF specified, aborting"
+		return 1
+	fi
+
+	driver=$(collect_driver "$bdf")
+	jq -n --arg key "device_driver" --arg value "$driver" '{($key): $value}'
+}
+
 kmsg "spdk: $0 $* (start)"
 
 CMD=reset cache_pci_bus
@@ -921,6 +1034,14 @@ if [[ $os == Linux ]]; then
 		reset_linux
 	elif [ "$mode" == "status" ]; then
 		status_linux
+	elif [ "$mode" == "disk-status" ]; then
+		disk_status_linux "$2"
+	elif [ "$mode" == "disk-driver" ]; then
+		disk_driver_linux "$2"
+	elif [ "$mode" == "bind" ]; then
+		bind_linux
+	elif [ "$mode" == "unbind" ]; then
+		unbind_linux "$2"
 	elif [ "$mode" == "help" ]; then
 		usage $0
 	else

--- a/test/bdev/bdev_raid.sh
+++ b/test/bdev/bdev_raid.sh
@@ -848,6 +848,136 @@ function raid_io_error_test() {
 	fi
 }
 
+function raid_grow_test() {
+	local raid_level=$1
+	local num_base_bdevs=$2
+	local superblock=$3
+	local background_io=$4
+	local base_bdevs=($(for ((i = 1; i <= num_base_bdevs; i++)); do echo BaseBdev$i; done))
+	local raid_bdev_name="raid_bdev1"
+	local strip_size=0
+	local create_arg
+	local raid_bdev_size
+	local data_offset
+
+	if [ $raid_level != "raid1" ]; then
+		echo "skipping grow test for level $raid_level"
+		return 1
+	fi
+
+	if [ $superblock = true ]; then
+		create_arg+=" -s"
+	fi
+
+	"$rootdir/build/examples/bdevperf" -r $rpc_server -T $raid_bdev_name -t 60 -w randrw -M 50 -o 3M -q 2 -U -z -L bdev_raid &
+	raid_pid=$!
+	waitforlisten $raid_pid $rpc_server
+
+	# Create base bdevs
+	for bdev in "${base_bdevs[@]}"; do
+		if [ $superblock = true ]; then
+			$rpc_py bdev_malloc_create 32 $base_blocklen $base_malloc_params -b ${bdev}_malloc
+			$rpc_py bdev_passthru_create -b ${bdev}_malloc -p $bdev
+		else
+			$rpc_py bdev_malloc_create 32 $base_blocklen $base_malloc_params -b $bdev
+		fi
+	done
+
+	# Create spare bdev
+	if [ $superblock = true ]; then
+		$rpc_py bdev_malloc_create 32 $base_blocklen $base_malloc_params -b "spare_malloc"
+		$rpc_py bdev_passthru_create -b "spare_malloc" -p "spare"
+	else
+		$rpc_py bdev_malloc_create 32 $base_blocklen $base_malloc_params -b "spare"
+	fi
+
+	# Create RAID bdev
+	$rpc_py bdev_raid_create $create_arg -r $raid_level -b "${base_bdevs[*]}" -n $raid_bdev_name
+	echo $raid_bdev_name $raid_level $strip_size $num_base_bdevs
+	verify_raid_bdev_state $raid_bdev_name "online" $raid_level $strip_size $num_base_bdevs
+
+	# Get RAID bdev's size
+	raid_bdev_size=$($rpc_py bdev_get_bdevs -b $raid_bdev_name | jq -r '.[].num_blocks')
+
+	# Get base bdev's data offset
+	data_offset=$($rpc_py bdev_raid_get_bdevs all | jq -r '.[].base_bdevs_list[0].data_offset')
+
+	if [ $background_io = true ]; then
+		# Start user I/O
+		"$rootdir/examples/bdev/bdevperf/bdevperf.py" -s $rpc_server perform_tests &
+	else
+		# Write random data to the first half of RAID bdev
+		nbd_start_disks $rpc_server $raid_bdev_name /dev/nbd0
+		dd if=/dev/urandom of=/dev/nbd0 bs=$base_blocklen count=$((raid_bdev_size / 2)) oflag=direct
+		nbd_stop_disks $rpc_server /dev/nbd0
+	fi
+
+	local num_base_bdevs_operational=$num_base_bdevs
+	if [ $raid_level = "raid1" ] && [ $num_base_bdevs -gt 2 ]; then
+		# Remove one base bdev
+		$rpc_py bdev_raid_remove_base_bdev ${base_bdevs[2]}
+
+		# Ignore this bdev later when comparing data
+		base_bdevs[2]=""
+		((num_base_bdevs_operational--))
+
+		# Check RAID status
+		verify_raid_bdev_state $raid_bdev_name "online" $raid_level $strip_size $num_base_bdevs_operational
+	fi
+
+	# Grow raid with one new base bdev
+	$rpc_py bdev_raid_grow_base_bdev $raid_bdev_name "spare"
+	((num_base_bdevs_operational++))
+
+	# Check RAID status
+	verify_raid_bdev_state $raid_bdev_name "online" $raid_level $strip_size $num_base_bdevs_operational
+
+	if [ $background_io = false ]; then
+		# Write random data to the second half of RAID bdev
+		nbd_start_disks $rpc_server $raid_bdev_name /dev/nbd0
+		dd if=/dev/urandom of=/dev/nbd0 bs=$base_blocklen count=$((raid_bdev_size / 2)) seek=$((raid_bdev_size / 2)) oflag=direct
+		nbd_stop_disks $rpc_server /dev/nbd0
+	fi
+
+	# Stop the RAID bdev
+	$rpc_py bdev_raid_delete $raid_bdev_name
+	[[ $($rpc_py bdev_raid_get_bdevs all | jq 'length') == 0 ]]
+
+	if [ $background_io = false ]; then
+		# Compare second half data on the spare and other base bdevs
+		nbd_start_disks $rpc_server "spare" "/dev/nbd0"
+		for bdev in "${base_bdevs[@]:1}"; do
+			if [ -z "$bdev" ]; then
+				continue
+			fi
+			nbd_start_disks $rpc_server $bdev "/dev/nbd1"
+			cmp -i $((data_offset * base_blocklen + raid_bdev_size * base_blocklen / 2)) /dev/nbd0 /dev/nbd1
+			nbd_stop_disks $rpc_server "/dev/nbd1"
+		done
+		nbd_stop_disks $rpc_server "/dev/nbd0"
+	fi
+
+	if [ $superblock = true ]; then
+		# Remove the passthru base bdevs, then re-add them to assemble the raid bdev again
+		for bdev in "${base_bdevs[@]}"; do
+			if [ -z "$bdev" ]; then
+				continue
+			fi
+			$rpc_py bdev_passthru_delete $bdev
+			$rpc_py bdev_passthru_create -b ${bdev}_malloc -p $bdev
+		done
+		$rpc_py bdev_passthru_delete "spare"
+		$rpc_py bdev_passthru_create -b "spare_malloc" -p "spare"
+
+		verify_raid_bdev_state $raid_bdev_name "online" $raid_level $strip_size $num_base_bdevs_operational
+		[[ $($rpc_py bdev_raid_get_bdevs all | jq -r '.[].base_bdevs_list[2].name') == "spare" ]]
+	fi
+
+	killprocess $raid_pid
+
+	return 0
+}
+
 mkdir -p "$tmp_dir"
 trap 'cleanup; exit 1' EXIT
 
@@ -878,6 +1008,10 @@ if [ "$has_nbd" = true ]; then
 		run_test "raid_rebuild_test_sb" raid_rebuild_test raid1 $n true false true
 		run_test "raid_rebuild_test_io" raid_rebuild_test raid1 $n false true true
 		run_test "raid_rebuild_test_sb_io" raid_rebuild_test raid1 $n true true true
+		run_test "raid_grow_test" raid_grow_test raid1 $n false false
+		run_test "raid_grow_test" raid_grow_test raid1 $n true false
+		run_test "raid_grow_test" raid_grow_test raid1 $n false true
+		run_test "raid_grow_test" raid_grow_test raid1 $n true true
 	done
 fi
 

--- a/test/lvol/esnap/esnap.c
+++ b/test/lvol/esnap/esnap.c
@@ -510,7 +510,7 @@ esnap_remove_degraded(void)
 	 * State:
 	 *   esnap <-- vol2 <-- vol1
 	 */
-	vbdev_lvol_create_snapshot(vol1, "vol2", lvol_op_with_handle_cb, clear_owh(&owh_data));
+	vbdev_lvol_create_snapshot(vol1, "vol2", NULL, 0, lvol_op_with_handle_cb, clear_owh(&owh_data));
 	poll_error_updated(&owh_data.lvserrno);
 	SPDK_CU_ASSERT_FATAL(owh_data.lvserrno == 0);
 	SPDK_CU_ASSERT_FATAL(owh_data.u.lvol != NULL);

--- a/test/lvol/fragmap.sh
+++ b/test/lvol/fragmap.sh
@@ -9,33 +9,191 @@ source $rootdir/test/common/autotest_common.sh
 source $rootdir/test/lvol/common.sh
 source $rootdir/test/bdev/nbd_common.sh
 
-function test_fragmap() {
-	# Create lvs
-	bs_malloc_name=$(rpc_cmd bdev_malloc_create 20 $MALLOC_BS)
-	lvs_uuid=$(rpc_cmd bdev_lvol_create_lvstore "$bs_malloc_name" lvs_test)
+NUM_CLUSTERS=10
+LVS_DEFAULT_CLUSTER_SIZE_BTYE=$((LVS_DEFAULT_CLUSTER_SIZE_MB * 1024 * 1024))
 
-	# Create lvol with 4 cluster
-	lvol_size=$((LVS_DEFAULT_CLUSTER_SIZE_MB * 4))
+function verify() {
+	local fragmap="$1"
+	local expected_cluster_size="$2"
+	local expected_num_clusters="$3"
+	local expected_num_allocated_clusters="$4"
+	local expected_fragmap="$5"
+
+	[ "$(jq '.cluster_size' <<< "$fragmap")" == "$expected_cluster_size" ]
+	[ "$(jq '.num_clusters' <<< "$fragmap")" == "$expected_num_clusters" ]
+	[ "$(jq '.num_allocated_clusters' <<< "$fragmap")" == "$expected_num_allocated_clusters" ]
+	[ "$(jq -r '.fragmap' <<< "$fragmap")" == "$expected_fragmap" ]
+}
+
+function test_fragmap_empty_lvol() {
+	# Create lvs
+	malloc_name=$(rpc_cmd bdev_malloc_create 80 $MALLOC_BS)
+	lvs_uuid=$(rpc_cmd bdev_lvol_create_lvstore "$malloc_name" lvs_test)
+
+	# Create lvol with 10 cluster
+	lvol_size=$((LVS_DEFAULT_CLUSTER_SIZE_MB * "$NUM_CLUSTERS"))
 	lvol_uuid=$(rpc_cmd bdev_lvol_create -u "$lvs_uuid" lvol_test "$lvol_size" -t)
 
-	# Fill second and fourth cluster of lvol
 	nbd_start_disks "$DEFAULT_RPC_ADDR" "$lvol_uuid" /dev/nbd0
-	dd if=/dev/urandom of=/dev/nbd0 oflag=direct bs="$LVS_DEFAULT_CLUSTER_SIZE" count=1 seek=1
-	dd if=/dev/urandom of=/dev/nbd0 oflag=direct bs="$LVS_DEFAULT_CLUSTER_SIZE" count=1 seek=3
+
+	# Expected map: 00000000 00000000
+	fragmap=$(rpc_cmd bdev_lvol_get_fragmap $lvol_uuid)
+	verify "$fragmap" "$LVS_DEFAULT_CLUSTER_SIZE_BTYE" "$NUM_CLUSTERS" 0 "AAA="
+
+	# Stop nbd device
 	nbd_stop_disks "$DEFAULT_RPC_ADDR" /dev/nbd0
 
-	# Create snapshots of lvol bdev
-	snapshot_uuid=$(rpc_cmd bdev_lvol_snapshot lvs_test/lvol_test lvol_snapshot)
+	rpc_cmd bdev_lvol_delete_lvstore -u "$lvs_uuid"
+	rpc_cmd bdev_lvol_get_lvstores -u "$lvs_uuid" && false
+	rpc_cmd bdev_malloc_delete "$malloc_name"
+	check_leftover_devices
+}
 
-	# Fill first and third cluster of lvol
+function test_fragmap_data_hole() {
+	# Create lvs
+	malloc_name=$(rpc_cmd bdev_malloc_create 80 $MALLOC_BS)
+	lvs_uuid=$(rpc_cmd bdev_lvol_create_lvstore "$malloc_name" lvs_test)
+
+	# Create lvol with 10 cluster
+	lvol_size=$((LVS_DEFAULT_CLUSTER_SIZE_MB * "$NUM_CLUSTERS"))
+	lvol_uuid=$(rpc_cmd bdev_lvol_create -u "$lvs_uuid" lvol_test "$lvol_size" -t)
+
 	nbd_start_disks "$DEFAULT_RPC_ADDR" "$lvol_uuid" /dev/nbd0
-	dd if=/dev/urandom of=/dev/nbd0 oflag=direct bs="$LVS_DEFAULT_CLUSTER_SIZE" count=1
-	dd if=/dev/urandom of=/dev/nbd0 oflag=direct bs="$LVS_DEFAULT_CLUSTER_SIZE" count=1 seek=2
+
+	# Expected map: 00000001 00000000 (1st cluster is wriiten)
+
+	# Read entire fragmap
+	dd if=/dev/urandom of=/dev/nbd0 oflag=direct bs=4096 count=1
+	fragmap=$(rpc_cmd bdev_lvol_get_fragmap $lvol_uuid)
+	verify "$fragmap" "$LVS_DEFAULT_CLUSTER_SIZE_BTYE" "$NUM_CLUSTERS" "1" "AQA="
+
+	# Read fragmap [0, 5) clusters
+	size=$((LVS_DEFAULT_CLUSTER_SIZE_BTYE * 5))
+	fragmap=$(rpc_cmd bdev_lvol_get_fragmap --offset 0 --size $size $lvol_uuid)
+	verify "$fragmap" "$LVS_DEFAULT_CLUSTER_SIZE_BTYE" "5" "1" "AQ=="
+
+	# Read fragmap [5, 10) clusters
+	offset=$((LVS_DEFAULT_CLUSTER_SIZE_BTYE * 5))
+	fragmap=$(rpc_cmd bdev_lvol_get_fragmap --offset $offset --size $size $lvol_uuid)
+	verify "$fragmap" "$LVS_DEFAULT_CLUSTER_SIZE_BTYE" "5" "0" "AA=="
+
+	# Stop nbd device
 	nbd_stop_disks "$DEFAULT_RPC_ADDR" /dev/nbd0
 
-	# Stop nbd devices
-	nbd_stop_disks "$DEFAULT_RPC_ADDR" /dev/nbd1
+	rpc_cmd bdev_lvol_delete_lvstore -u "$lvs_uuid"
+	rpc_cmd bdev_lvol_get_lvstores -u "$lvs_uuid" && false
+	rpc_cmd bdev_malloc_delete "$malloc_name"
+	check_leftover_devices
+}
+function test_fragmap_hole_data() {
+	# Create lvs
+	malloc_name=$(rpc_cmd bdev_malloc_create 80 $MALLOC_BS)
+	lvs_uuid=$(rpc_cmd bdev_lvol_create_lvstore "$malloc_name" lvs_test)
+	# Create lvol with 10 cluster
+	lvol_size=$((LVS_DEFAULT_CLUSTER_SIZE_MB * "$NUM_CLUSTERS"))
+	lvol_uuid=$(rpc_cmd bdev_lvol_create -u "$lvs_uuid" lvol_test "$lvol_size" -t)
+
+	nbd_start_disks "$DEFAULT_RPC_ADDR" "$lvol_uuid" /dev/nbd0
+
+	# Expected map: 00000000 00000010 (10th cluster is wriiten)
+
+	# Read entire fragmap
+	dd if=/dev/urandom of=/dev/nbd0 oflag=direct bs=4096 count=1 seek=9216
+	fragmap=$(rpc_cmd bdev_lvol_get_fragmap $lvol_uuid)
+	verify "$fragmap" "$LVS_DEFAULT_CLUSTER_SIZE_BTYE" "$NUM_CLUSTERS" "1" "AAI="
+
+	# Read fragmap [0, 5) clusters
+	size=$((LVS_DEFAULT_CLUSTER_SIZE_BTYE * 5))
+	fragmap=$(rpc_cmd bdev_lvol_get_fragmap --offset 0 --size $size $lvol_uuid)
+	verify "$fragmap" "$LVS_DEFAULT_CLUSTER_SIZE_BTYE" "5" "0" "AA=="
+
+	# Read fragmap [5, 10) clusters
+	offset=$((LVS_DEFAULT_CLUSTER_SIZE_BTYE * 5))
+	fragmap=$(rpc_cmd bdev_lvol_get_fragmap --offset $offset --size $size $lvol_uuid)
+	verify "$fragmap" "$LVS_DEFAULT_CLUSTER_SIZE_BTYE" "5" "1" "EA=="
+
+	# Stop nbd device
 	nbd_stop_disks "$DEFAULT_RPC_ADDR" /dev/nbd0
+
+	rpc_cmd bdev_lvol_delete_lvstore -u "$lvs_uuid"
+	rpc_cmd bdev_lvol_get_lvstores -u "$lvs_uuid" && false
+	rpc_cmd bdev_malloc_delete "$malloc_name"
+	check_leftover_devices
+}
+
+function test_fragmap_hole_data_hole() {
+	# Create lvs
+	malloc_name=$(rpc_cmd bdev_malloc_create 80 $MALLOC_BS)
+	lvs_uuid=$(rpc_cmd bdev_lvol_create_lvstore "$malloc_name" lvs_test)
+
+	# Create lvol with 10 cluster
+	lvol_size=$((LVS_DEFAULT_CLUSTER_SIZE_MB * "$NUM_CLUSTERS"))
+	lvol_uuid=$(rpc_cmd bdev_lvol_create -u "$lvs_uuid" lvol_test "$lvol_size" -t)
+
+	nbd_start_disks "$DEFAULT_RPC_ADDR" "$lvol_uuid" /dev/nbd0
+
+	# Expected map: 01100000 00000000
+
+	# Read entire fragmap
+	dd if=/dev/urandom of=/dev/nbd0 oflag=direct bs=4096 count=2048 seek=5120
+	fragmap=$(rpc_cmd bdev_lvol_get_fragmap $lvol_uuid)
+	verify "$fragmap" "$LVS_DEFAULT_CLUSTER_SIZE_BTYE" "$NUM_CLUSTERS" "2" "YAA="
+
+	# Read fragmap [0, 5) clusters
+	size=$((LVS_DEFAULT_CLUSTER_SIZE_BTYE * 5))
+	fragmap=$(rpc_cmd bdev_lvol_get_fragmap --offset 0 --size $size $lvol_uuid)
+	verify "$fragmap" "$LVS_DEFAULT_CLUSTER_SIZE_BTYE" "5" "0" "AA=="
+
+	# Read fragmap [5, 10) clusters
+	offset=$((LVS_DEFAULT_CLUSTER_SIZE_BTYE * 5))
+	fragmap=$(rpc_cmd bdev_lvol_get_fragmap --offset $offset --size $size $lvol_uuid)
+	verify "$fragmap" "$LVS_DEFAULT_CLUSTER_SIZE_BTYE" "5" "2" "Aw=="
+
+	# Stop nbd device
+	nbd_stop_disks "$DEFAULT_RPC_ADDR" /dev/nbd0
+
+	rpc_cmd bdev_lvol_delete_lvstore -u "$lvs_uuid"
+	rpc_cmd bdev_lvol_get_lvstores -u "$lvs_uuid" && false
+	rpc_cmd bdev_malloc_delete "$malloc_name"
+	check_leftover_devices
+}
+
+function test_fragmap_data_hole_data() {
+	# Create lvs
+	malloc_name=$(rpc_cmd bdev_malloc_create 80 $MALLOC_BS)
+	lvs_uuid=$(rpc_cmd bdev_lvol_create_lvstore "$malloc_name" lvs_test)
+
+	# Create lvol with 10 cluster
+	lvol_size=$((LVS_DEFAULT_CLUSTER_SIZE_MB * "$NUM_CLUSTERS"))
+	lvol_uuid=$(rpc_cmd bdev_lvol_create -u "$lvs_uuid" lvol_test "$lvol_size" -t)
+
+	nbd_start_disks "$DEFAULT_RPC_ADDR" "$lvol_uuid" /dev/nbd0
+
+	# Expected map: 10000111 00000011
+
+	# Read entire fragmap
+	dd if=/dev/urandom of=/dev/nbd0 oflag=direct bs=4096 count=3072 seek=0
+	dd if=/dev/urandom of=/dev/nbd0 oflag=direct bs=4096 count=3072 seek=7168
+	fragmap=$(rpc_cmd bdev_lvol_get_fragmap $lvol_uuid)
+	verify "$fragmap" "$LVS_DEFAULT_CLUSTER_SIZE_BTYE" "$NUM_CLUSTERS" "6" "hwM="
+
+	# Read fragmap [0, 5) clusters
+	size=$((LVS_DEFAULT_CLUSTER_SIZE_BTYE * 5))
+	fragmap=$(rpc_cmd bdev_lvol_get_fragmap --offset 0 --size $size $lvol_uuid)
+	verify "$fragmap" "$LVS_DEFAULT_CLUSTER_SIZE_BTYE" "5" "3" "Bw=="
+
+	# Read fragmap [5, 10) clusters
+	offset=$((LVS_DEFAULT_CLUSTER_SIZE_BTYE * 5))
+	fragmap=$(rpc_cmd bdev_lvol_get_fragmap --offset $offset --size $size $lvol_uuid)
+	verify "$fragmap" "$LVS_DEFAULT_CLUSTER_SIZE_BTYE" "5" "3" "HA=="
+
+	# Stop nbd device
+	nbd_stop_disks "$DEFAULT_RPC_ADDR" /dev/nbd0
+
+	rpc_cmd bdev_lvol_delete_lvstore -u "$lvs_uuid"
+	rpc_cmd bdev_lvol_get_lvstores -u "$lvs_uuid" && false
+	rpc_cmd bdev_malloc_delete "$malloc_name"
+	check_leftover_devices
 }
 
 $SPDK_BIN_DIR/spdk_tgt &
@@ -44,7 +202,11 @@ trap 'killprocess "$spdk_pid"; exit 1' SIGINT SIGTERM EXIT
 waitforlisten $spdk_pid
 modprobe nbd
 
-run_test "test_shallow_copy_compare" test_shallow_copy_compare
+run_test "test_fragmap_empty_lvol" test_fragmap_empty_lvol
+run_test "test_fragmap_data_hole" test_fragmap_data_hole
+run_test "test_fragmap_hole_data" test_fragmap_hole_data
+run_test "test_fragmap_hole_data_hole" test_fragmap_hole_data_hole
+run_test "test_fragmap_data_hole_data" test_fragmap_data_hole_data
 
 trap - SIGINT SIGTERM EXIT
 killprocess $spdk_pid

--- a/test/lvol/fragmap.sh
+++ b/test/lvol/fragmap.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#  SPDX-License-Identifier: BSD-3-Clause
+#  Copyright (C) 2023 SUSE LLC.
+#  All rights reserved.
+#
+testdir=$(readlink -f $(dirname $0))
+rootdir=$(readlink -f $testdir/../..)
+source $rootdir/test/common/autotest_common.sh
+source $rootdir/test/lvol/common.sh
+source $rootdir/test/bdev/nbd_common.sh
+
+function test_fragmap() {
+	# Create lvs
+	bs_malloc_name=$(rpc_cmd bdev_malloc_create 20 $MALLOC_BS)
+	lvs_uuid=$(rpc_cmd bdev_lvol_create_lvstore "$bs_malloc_name" lvs_test)
+
+	# Create lvol with 4 cluster
+	lvol_size=$((LVS_DEFAULT_CLUSTER_SIZE_MB * 4))
+	lvol_uuid=$(rpc_cmd bdev_lvol_create -u "$lvs_uuid" lvol_test "$lvol_size" -t)
+
+	# Fill second and fourth cluster of lvol
+	nbd_start_disks "$DEFAULT_RPC_ADDR" "$lvol_uuid" /dev/nbd0
+	dd if=/dev/urandom of=/dev/nbd0 oflag=direct bs="$LVS_DEFAULT_CLUSTER_SIZE" count=1 seek=1
+	dd if=/dev/urandom of=/dev/nbd0 oflag=direct bs="$LVS_DEFAULT_CLUSTER_SIZE" count=1 seek=3
+	nbd_stop_disks "$DEFAULT_RPC_ADDR" /dev/nbd0
+
+	# Create snapshots of lvol bdev
+	snapshot_uuid=$(rpc_cmd bdev_lvol_snapshot lvs_test/lvol_test lvol_snapshot)
+
+	# Fill first and third cluster of lvol
+	nbd_start_disks "$DEFAULT_RPC_ADDR" "$lvol_uuid" /dev/nbd0
+	dd if=/dev/urandom of=/dev/nbd0 oflag=direct bs="$LVS_DEFAULT_CLUSTER_SIZE" count=1
+	dd if=/dev/urandom of=/dev/nbd0 oflag=direct bs="$LVS_DEFAULT_CLUSTER_SIZE" count=1 seek=2
+	nbd_stop_disks "$DEFAULT_RPC_ADDR" /dev/nbd0
+
+	# Stop nbd devices
+	nbd_stop_disks "$DEFAULT_RPC_ADDR" /dev/nbd1
+	nbd_stop_disks "$DEFAULT_RPC_ADDR" /dev/nbd0
+}
+
+$SPDK_BIN_DIR/spdk_tgt &
+spdk_pid=$!
+trap 'killprocess "$spdk_pid"; exit 1' SIGINT SIGTERM EXIT
+waitforlisten $spdk_pid
+modprobe nbd
+
+run_test "test_shallow_copy_compare" test_shallow_copy_compare
+
+trap - SIGINT SIGTERM EXIT
+killprocess $spdk_pid

--- a/test/lvol/lvol.sh
+++ b/test/lvol/lvol.sh
@@ -21,6 +21,7 @@ run_test "lvol_provisioning" $rootdir/test/lvol/thin_provisioning.sh
 run_test "lvol_esnap" $rootdir/test/lvol/esnap/esnap
 run_test "lvol_external_snapshot" $rootdir/test/lvol/external_snapshot.sh
 run_test "lvol_external_copy" $rootdir/test/lvol/external_copy.sh
+run_test "lvol_fragmap" $rootdir/test/lvol/fragmap.sh
 timing_exit basic
 
 timing_exit lvol

--- a/test/lvol/lvol.sh
+++ b/test/lvol/lvol.sh
@@ -22,6 +22,7 @@ run_test "lvol_esnap" $rootdir/test/lvol/esnap/esnap
 run_test "lvol_external_snapshot" $rootdir/test/lvol/external_snapshot.sh
 run_test "lvol_external_copy" $rootdir/test/lvol/external_copy.sh
 run_test "lvol_fragmap" $rootdir/test/lvol/fragmap.sh
+run_test "lvol_xattr" $rootdir/test/lvol/xattr.sh
 timing_exit basic
 
 timing_exit lvol

--- a/test/lvol/xattr.sh
+++ b/test/lvol/xattr.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#  SPDX-License-Identifier: BSD-3-Clause
+#  Copyright (C) 2023 SUSE LLC.
+#  All rights reserved.
+#
+testdir=$(readlink -f $(dirname $0))
+rootdir=$(readlink -f $testdir/../..)
+source $rootdir/test/common/autotest_common.sh
+source $rootdir/test/lvol/common.sh
+
+function is_rfc3339_formatted() {
+	# Define the RFC3339 regex pattern
+	rfc3339_pattern="^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"
+
+	# Check if the input string matches the pattern
+	if [[ $1 =~ $rfc3339_pattern ]]; then
+		echo "The time string '$1' is in RFC3339 format."
+		return 0 # Success
+	else
+		echo "The time string '$1' is not in RFC3339 format."
+		return 1 # Failure
+	fi
+}
+
+function test_set_xattr() {
+	# Create lvs
+	malloc_name=$(rpc_cmd bdev_malloc_create 20 $MALLOC_BS)
+	lvs_uuid=$(rpc_cmd bdev_lvol_create_lvstore "$malloc_name" lvs_test)
+
+	# Create lvol with 4 cluster
+	lvol_size=$((LVS_DEFAULT_CLUSTER_SIZE_MB * 4))
+	lvol_uuid=$(rpc_cmd bdev_lvol_create -u "$lvs_uuid" lvol_test "$lvol_size" -t)
+
+	rpc_cmd bdev_lvol_set_xattr "$lvol_uuid" "foo" "bar"
+	value=$(rpc_cmd bdev_lvol_get_xattr "$lvol_uuid" "foo")
+	[ "\"bar\"" = "$value" ]
+
+	# Snapshot is read-only, so setting xattr should fail
+	snapshot_uuid=$(rpc_cmd bdev_lvol_snapshot lvs_test/lvol_test lvol_snapshot)
+	NOT rpc_cmd bdev_lvol_set_xattr "$snapshot_uuid" "foo" "bar"
+
+	rpc_cmd bdev_lvol_delete_lvstore -u "$lvs_uuid"
+	rpc_cmd bdev_malloc_delete "$malloc_name"
+	check_leftover_devices
+}
+
+function test_creation_time_xattr() {
+	# Create lvs
+	malloc_name=$(rpc_cmd bdev_malloc_create 20 $MALLOC_BS)
+	lvs_uuid=$(rpc_cmd bdev_lvol_create_lvstore "$malloc_name" lvs_test)
+
+	# Create lvol with 4 cluster
+	lvol_size=$((LVS_DEFAULT_CLUSTER_SIZE_MB * 4))
+	lvol_uuid=$(rpc_cmd bdev_lvol_create -u "$lvs_uuid" lvol_test "$lvol_size" -t)
+
+	value=$(rpc_cmd bdev_lvol_get_xattr "$lvol_uuid" "creation_time")
+	value="${value//\"/}"
+	is_rfc3339_formatted ${value}
+
+	# Create snapshots of lvol bdev
+	snapshot_uuid=$(rpc_cmd bdev_lvol_snapshot lvs_test/lvol_test lvol_snapshot)
+	value=$(rpc_cmd bdev_lvol_get_xattr "$snapshot_uuid" "creation_time")
+	value="${value//\"/}"
+	is_rfc3339_formatted ${value}
+
+	clone_uuid=$(rpc_cmd bdev_lvol_clone "$snapshot_uuid" lvol_clone)
+	value=$(rpc_cmd bdev_lvol_get_xattr "$snapshot_uuid" "creation_time")
+	value="${value//\"/}"
+	is_rfc3339_formatted ${value}
+
+	rpc_cmd bdev_lvol_delete_lvstore -u "$lvs_uuid"
+	rpc_cmd bdev_malloc_delete "$malloc_name"
+	check_leftover_devices
+}
+
+$SPDK_BIN_DIR/spdk_tgt &
+spdk_pid=$!
+trap 'killprocess "$spdk_pid"; exit 1' SIGINT SIGTERM EXIT
+waitforlisten $spdk_pid
+modprobe nbd
+
+run_test "test_set_xattr" test_set_xattr
+run_test "test_creation_time_xattr" test_creation_time_xattr
+
+trap - SIGINT SIGTERM EXIT
+killprocess $spdk_pid

--- a/test/lvol/xattr.sh
+++ b/test/lvol/xattr.sh
@@ -39,6 +39,11 @@ function test_set_xattr() {
 	snapshot_uuid=$(rpc_cmd bdev_lvol_snapshot lvs_test/lvol_test lvol_snapshot)
 	NOT rpc_cmd bdev_lvol_set_xattr "$snapshot_uuid" "foo" "bar"
 
+	# Create snapshot with xattr
+	snapshotx_uuid=$(rpc_cmd bdev_lvol_snapshot --xattr snapshot_timestamp=2024-01-16T16:06:46Z lvs_test/lvol_test lvol_snapshotx)
+	value=$(rpc_cmd bdev_lvol_get_xattr "$snapshotx_uuid" "snapshot_timestamp")
+	[ "\"2024-01-16T16:06:46Z\"" = "$value" ]
+
 	rpc_cmd bdev_lvol_delete_lvstore -u "$lvs_uuid"
 	rpc_cmd bdev_malloc_delete "$malloc_name"
 	check_leftover_devices

--- a/test/unit/lib/bdev/raid/bdev_raid.c/bdev_raid_ut.c
+++ b/test/unit/lib/bdev/raid/bdev_raid.c/bdev_raid_ut.c
@@ -195,6 +195,10 @@ DEFINE_STUB(spdk_bdev_writev_blocks_ext, int, (struct spdk_bdev_desc *desc,
 		struct spdk_io_channel *ch, struct iovec *iov, int iovcnt, uint64_t offset_blocks,
 		uint64_t num_blocks, spdk_bdev_io_completion_cb cb, void *cb_arg,
 		struct spdk_bdev_ext_io_opts *opts), 0);
+DEFINE_STUB(spdk_bdev_unmap_blocks, int, (struct spdk_bdev_desc *desc,
+		struct spdk_io_channel *ch,
+		uint64_t offset_blocks, uint64_t num_blocks,
+		spdk_bdev_io_completion_cb cb, void *cb_arg), 0);
 
 uint32_t
 spdk_bdev_get_data_block_size(const struct spdk_bdev *bdev)

--- a/test/unit/lib/bdev/raid/bdev_raid.c/bdev_raid_ut.c
+++ b/test/unit/lib/bdev/raid/bdev_raid.c/bdev_raid_ut.c
@@ -12,6 +12,7 @@
 #include "bdev/raid/bdev_raid.c"
 #include "bdev/raid/bdev_raid_rpc.c"
 #include "common/lib/test_env.c"
+#include "bdev/raid/raid1.c"
 
 #define MAX_BASE_DRIVES 32
 #define MAX_RAIDS 2
@@ -821,7 +822,8 @@ create_base_bdevs(uint32_t bbdev_start_idx)
 
 static void
 create_test_req(struct rpc_bdev_raid_create *r, const char *raid_name,
-		uint8_t bbdev_start_idx, bool create_base_bdev, bool superblock_enabled)
+		uint8_t bbdev_start_idx, bool create_base_bdev, bool superblock_enabled,
+		uint8_t num_base_bdev_to_use)
 {
 	uint8_t i;
 	char name[16];
@@ -832,8 +834,8 @@ create_test_req(struct rpc_bdev_raid_create *r, const char *raid_name,
 	r->strip_size_kb = (g_strip_size * g_block_len) / 1024;
 	r->level = 123;
 	r->superblock_enabled = superblock_enabled;
-	r->base_bdevs.num_base_bdevs = g_max_base_drives;
-	for (i = 0; i < g_max_base_drives; i++, bbdev_idx++) {
+	r->base_bdevs.num_base_bdevs = num_base_bdev_to_use;
+	for (i = 0; i < num_base_bdev_to_use; i++, bbdev_idx++) {
 		snprintf(name, 16, "%s%u%s", "Nvme", bbdev_idx, "n1");
 		r->base_bdevs.base_bdevs[i] = strdup(name);
 		SPDK_CU_ASSERT_FATAL(r->base_bdevs.base_bdevs[i] != NULL);
@@ -846,16 +848,27 @@ create_test_req(struct rpc_bdev_raid_create *r, const char *raid_name,
 }
 
 static void
-create_raid_bdev_create_req(struct rpc_bdev_raid_create *r, const char *raid_name,
-			    uint8_t bbdev_start_idx, bool create_base_bdev,
-			    uint8_t json_decode_obj_err, bool superblock_enabled)
+_create_raid_bdev_create_req(struct rpc_bdev_raid_create *r, const char *raid_name,
+			     uint8_t bbdev_start_idx, bool create_base_bdev,
+			     uint8_t json_decode_obj_err, bool superblock_enabled,
+			     uint8_t num_base_bdev_to_use)
 {
-	create_test_req(r, raid_name, bbdev_start_idx, create_base_bdev, superblock_enabled);
+	create_test_req(r, raid_name, bbdev_start_idx, create_base_bdev, superblock_enabled,
+			num_base_bdev_to_use);
 
 	g_rpc_err = 0;
 	g_json_decode_obj_create = 1;
 	g_json_decode_obj_err = json_decode_obj_err;
 	g_test_multi_raids = 0;
+}
+
+static void
+create_raid_bdev_create_req(struct rpc_bdev_raid_create *r, const char *raid_name,
+			    uint8_t bbdev_start_idx, bool create_base_bdev,
+			    uint8_t json_decode_obj_err, bool superblock)
+{
+	_create_raid_bdev_create_req(r, raid_name, bbdev_start_idx, create_base_bdev,
+				     json_decode_obj_err, superblock, g_max_base_drives);
 }
 
 static void
@@ -1680,6 +1693,193 @@ test_raid_io_split(void)
 	reset_globals();
 }
 
+static void
+test_raid_grow_base_bdev_not_supported(void)
+{
+	struct rpc_bdev_raid_create req;
+	struct rpc_bdev_raid_delete destroy_req;
+	struct raid_bdev *pbdev;
+	int rc;
+
+	set_globals();
+	CU_ASSERT(raid_bdev_init() == 0);
+
+	verify_raid_bdev_present("raid0", false);
+	create_raid_bdev_create_req(&req, "raid0", 0, true, 0, false);
+	rpc_bdev_raid_create(NULL, NULL);
+	CU_ASSERT(g_rpc_err == 0);
+
+	TAILQ_FOREACH(pbdev, &g_raid_bdev_list, global_link) {
+		if (strcmp(pbdev->bdev.name, "raid0") == 0) {
+			break;
+		}
+	}
+	CU_ASSERT(pbdev != NULL);
+
+	/* Only RAID1 level actually support grow base bdev operation */
+	rc = raid_bdev_grow_base_bdev(pbdev, "", NULL, NULL);
+	CU_ASSERT(rc == -EPERM);
+	free_test_req(&req);
+
+	create_raid_bdev_delete_req(&destroy_req, "raid0", 0);
+	rpc_bdev_raid_delete(NULL, NULL);
+	CU_ASSERT(g_rpc_err == 0);
+	verify_raid_bdev_present("raid0", false);
+
+	raid_bdev_exit();
+	base_bdevs_cleanup();
+	reset_globals();
+}
+
+static void
+grow_base_bdev_cb(void *cb_arg, int rc)
+{
+	*(int *)cb_arg = rc;
+}
+
+static void
+test_raid_grow_base_bdev(void)
+{
+	struct rpc_bdev_raid_create req;
+	struct rpc_bdev_raid_delete destroy_req;
+	struct raid_bdev *pbdev;
+	char name1[16], name2[16];
+	struct spdk_io_channel *ch;
+	int grow_base_bdev_cb_output;
+	int rc;
+
+	set_globals();
+	CU_ASSERT(raid_bdev_init() == 0);
+
+	snprintf(name1, 16, "%s%u%s", "Nvme", g_max_base_drives - 1, "n1");
+	snprintf(name2, 16, "%s%u%s", "Nvme", g_max_base_drives - 2, "n1");
+
+	/* Create a raid with RAID1 level */
+	verify_raid_bdev_present("raid1", false);
+	_create_raid_bdev_create_req(&req, "raid1", 0, true, 0, false,
+				     g_max_base_drives - 2);
+	req.strip_size_kb = 0;
+	req.level = RAID1;
+	rpc_bdev_raid_create(NULL, NULL);
+	CU_ASSERT(g_rpc_err == 0);
+	verify_raid_bdev(&req, true, RAID_BDEV_STATE_ONLINE);
+
+	TAILQ_FOREACH(pbdev, &g_raid_bdev_list, global_link) {
+		if (strcmp(pbdev->bdev.name, "raid1") == 0) {
+			break;
+		}
+	}
+	CU_ASSERT(pbdev != NULL);
+
+	/* Grow base bdev on a raid not online */
+	pbdev->state = RAID_BDEV_STATE_CONFIGURING;
+	rc = raid_bdev_grow_base_bdev(pbdev, name1, NULL, NULL);
+	CU_ASSERT(rc == -EINVAL);
+	pbdev->state = RAID_BDEV_STATE_ONLINE;
+
+	/* Grow raid adding base bdev successfully */
+	ch = spdk_get_io_channel(pbdev);
+	SPDK_CU_ASSERT_FATAL(ch != NULL);
+	grow_base_bdev_cb_output = 1;
+	CU_ASSERT(pbdev->num_base_bdevs == g_max_base_drives - 2);
+	rc = raid_bdev_grow_base_bdev(pbdev, name1, grow_base_bdev_cb,
+				      &grow_base_bdev_cb_output);
+	CU_ASSERT(rc == 0);
+
+	/* Grow base bdev with another operation running */
+	rc = raid_bdev_grow_base_bdev(pbdev, name2, NULL, NULL);
+	CU_ASSERT(rc == -EBUSY);
+
+	/* Check that new base bdev has been correctly added */
+	poll_app_thread();
+	CU_ASSERT(grow_base_bdev_cb_output == 0);
+	CU_ASSERT(pbdev->num_base_bdevs == g_max_base_drives - 1);
+
+	/* Try againg growing with the same base bdev */
+	rc = raid_bdev_grow_base_bdev(pbdev, name2, NULL, NULL);
+	CU_ASSERT(rc == 0);
+	poll_app_thread();
+
+	spdk_put_io_channel(ch);
+	free_test_req(&req);
+	create_raid_bdev_delete_req(&destroy_req, "raid1", 0);
+	rpc_bdev_raid_delete(NULL, NULL);
+	CU_ASSERT(g_rpc_err == 0);
+	verify_raid_bdev_present("raid1", false);
+
+	raid_bdev_exit();
+	base_bdevs_cleanup();
+	reset_globals();
+}
+
+static void
+test_raid_grow_base_bdev_with_hole(void)
+{
+	struct rpc_bdev_raid_create req;
+	struct rpc_bdev_raid_delete destroy_req;
+	struct raid_bdev *pbdev;
+	struct spdk_bdev *base_bdev;
+	char name[16];
+	struct spdk_io_channel *ch;
+	int grow_base_bdev_cb_output;
+	int rc;
+
+	set_globals();
+	CU_ASSERT(raid_bdev_init() == 0);
+
+	snprintf(name, 16, "%s%u%s", "Nvme", g_max_base_drives - 5, "n1");
+
+	/* Create a raid with RAID1 level */
+	verify_raid_bdev_present("raid1", false);
+	create_raid_bdev_create_req(&req, "raid1", 0, true, 0, false);
+	req.strip_size_kb = 0;
+	req.level = RAID1;
+	rpc_bdev_raid_create(NULL, NULL);
+	CU_ASSERT(g_rpc_err == 0);
+	verify_raid_bdev(&req, true, RAID_BDEV_STATE_ONLINE);
+
+	TAILQ_FOREACH(pbdev, &g_raid_bdev_list, global_link) {
+		if (strcmp(pbdev->bdev.name, "raid1") == 0) {
+			break;
+		}
+	}
+	CU_ASSERT(pbdev != NULL);
+
+	/* Remove a base bdev creating an hole */
+	base_bdev = spdk_bdev_get_by_name(name);
+	SPDK_CU_ASSERT_FATAL(base_bdev != NULL);
+	rc = raid_bdev_remove_base_bdev(base_bdev, grow_base_bdev_cb,
+					&grow_base_bdev_cb_output);
+	SPDK_CU_ASSERT_FATAL(rc == 0);
+	poll_app_thread();
+	SPDK_CU_ASSERT_FATAL(grow_base_bdev_cb_output == 0);
+
+	/* Grow raid adding base filling the hole */
+	ch = spdk_get_io_channel(pbdev);
+	SPDK_CU_ASSERT_FATAL(ch != NULL);
+	grow_base_bdev_cb_output = 1;
+	CU_ASSERT(pbdev->num_base_bdevs == g_max_base_drives);
+	rc = raid_bdev_grow_base_bdev(pbdev, name, grow_base_bdev_cb,
+				      &grow_base_bdev_cb_output);
+	CU_ASSERT(rc == 0);
+
+	/* Check that new base bdev has been correctly added in the hole */
+	poll_app_thread();
+	CU_ASSERT(grow_base_bdev_cb_output == 0);
+	CU_ASSERT(pbdev->num_base_bdevs == g_max_base_drives);
+
+	spdk_put_io_channel(ch);
+	free_test_req(&req);
+	create_raid_bdev_delete_req(&destroy_req, "raid1", 0);
+	rpc_bdev_raid_delete(NULL, NULL);
+	CU_ASSERT(g_rpc_err == 0);
+	verify_raid_bdev_present("raid1", false);
+
+	raid_bdev_exit();
+	base_bdevs_cleanup();
+	reset_globals();
+}
+
 static int
 test_new_thread_fn(struct spdk_thread *thread)
 {
@@ -1722,6 +1922,9 @@ main(int argc, char **argv)
 	CU_ADD_TEST(suite, test_raid_level_conversions);
 	CU_ADD_TEST(suite, test_raid_io_split);
 	CU_ADD_TEST(suite, test_raid_process);
+	CU_ADD_TEST(suite, test_raid_grow_base_bdev_not_supported);
+	CU_ADD_TEST(suite, test_raid_grow_base_bdev);
+	CU_ADD_TEST(suite, test_raid_grow_base_bdev_with_hole);
 
 	spdk_thread_lib_init(test_new_thread_fn, 0);
 	g_app_thread = spdk_thread_create("app_thread", NULL);

--- a/test/unit/lib/bdev/raid/common.c
+++ b/test/unit/lib/bdev/raid/common.c
@@ -184,6 +184,7 @@ raid_test_delete_raid_bdev(struct raid_bdev *raid_bdev)
 struct raid_bdev_io_channel {
 	struct spdk_io_channel **_base_channels;
 	struct spdk_io_channel *_module_channel;
+	uint8_t		       num_channels;
 };
 
 struct spdk_io_channel *
@@ -198,6 +199,12 @@ raid_bdev_channel_get_module_ctx(struct raid_bdev_io_channel *raid_ch)
 	return spdk_io_channel_get_ctx(raid_ch->_module_channel);
 }
 
+uint8_t
+raid_bdev_channel_get_num_channels(struct raid_bdev_io_channel *raid_ch)
+{
+	return raid_ch->num_channels;
+}
+
 struct raid_bdev_io_channel *
 raid_test_create_io_channel(struct raid_bdev *raid_bdev)
 {
@@ -209,6 +216,7 @@ raid_test_create_io_channel(struct raid_bdev *raid_bdev)
 
 	raid_ch->_base_channels = calloc(raid_bdev->num_base_bdevs, sizeof(struct spdk_io_channel *));
 	SPDK_CU_ASSERT_FATAL(raid_ch->_base_channels != NULL);
+	raid_ch->num_channels = raid_bdev->num_base_bdevs;
 
 	for (i = 0; i < raid_bdev->num_base_bdevs; i++) {
 		raid_ch->_base_channels[i] = (void *)1;

--- a/test/unit/lib/bdev/raid/raid1.c/raid1_ut.c
+++ b/test/unit/lib/bdev/raid/raid1.c/raid1_ut.c
@@ -30,6 +30,10 @@ DEFINE_STUB_V(raid_bdev_io_init, (struct raid_bdev_io *raid_io,
 				  struct spdk_memory_domain *memory_domain, void *memory_domain_ctx));
 DEFINE_STUB(raid_bdev_remap_dix_reftag, int, (void *md_buf, uint64_t num_blocks,
 		struct spdk_bdev *bdev, uint32_t remapped_offset), -1);
+DEFINE_STUB(spdk_bdev_flush_blocks, int, (struct spdk_bdev_desc *desc,
+		struct spdk_io_channel *ch,
+		uint64_t offset_blocks, uint64_t num_blocks,
+		spdk_bdev_io_completion_cb cb, void *cb_arg), 0);
 
 int
 spdk_bdev_readv_blocks_ext(struct spdk_bdev_desc *desc,

--- a/test/unit/lib/bdev/raid/raid1.c/raid1_ut.c
+++ b/test/unit/lib/bdev/raid/raid1.c/raid1_ut.c
@@ -34,6 +34,10 @@ DEFINE_STUB(spdk_bdev_flush_blocks, int, (struct spdk_bdev_desc *desc,
 		struct spdk_io_channel *ch,
 		uint64_t offset_blocks, uint64_t num_blocks,
 		spdk_bdev_io_completion_cb cb, void *cb_arg), 0);
+DEFINE_STUB(spdk_bdev_unmap_blocks, int, (struct spdk_bdev_desc *desc,
+		struct spdk_io_channel *ch,
+		uint64_t offset_blocks, uint64_t num_blocks,
+		spdk_bdev_io_completion_cb cb, void *cb_arg), 0);
 
 int
 spdk_bdev_readv_blocks_ext(struct spdk_bdev_desc *desc,

--- a/test/unit/lib/bdev/vbdev_lvol.c/vbdev_lvol_ut.c
+++ b/test/unit/lib/bdev/vbdev_lvol.c/vbdev_lvol_ut.c
@@ -38,6 +38,7 @@ bool g_bdev_alias_already_exists = false;
 bool g_lvs_with_name_already_exists = false;
 bool g_ext_api_called;
 bool g_bdev_is_missing = false;
+bool g_snapshot_xattr_called = false;
 
 DEFINE_STUB_V(spdk_bdev_module_fini_start_done, (void));
 DEFINE_STUB_V(spdk_bdev_update_bs_blockcnt, (struct spdk_bs_dev *bs_dev));
@@ -886,6 +887,8 @@ spdk_lvol_create_snapshot_with_xattrs(struct spdk_lvol *lvol, const char *snapsh
 				      const char *const *xattrs, size_t xattrs_num,
 				      spdk_lvol_op_with_handle_complete cb_fn, void *cb_arg)
 {
+	g_snapshot_xattr_called = true;
+	spdk_lvol_create_snapshot(lvol, snapshot_name, cb_fn, cb_arg);
 }
 
 void
@@ -1074,6 +1077,7 @@ ut_lvol_snapshot(void)
 	int sz = 10;
 	int rc;
 	struct spdk_lvol *lvol = NULL;
+	char *xattrs[] = {"par", "val"};
 
 	/* Lvol store is successfully created */
 	rc = vbdev_lvs_create("bdev", "lvs", 0, LVS_CLEAR_WITH_UNMAP, 0,
@@ -1095,10 +1099,31 @@ ut_lvol_snapshot(void)
 	lvol = g_lvol;
 
 	/* Successful snap create */
-	vbdev_lvol_create_snapshot(lvol, "snap", vbdev_lvol_create_complete, NULL);
+	vbdev_lvol_create_snapshot(lvol, "snap", NULL, 0, vbdev_lvol_create_complete, NULL);
 	SPDK_CU_ASSERT_FATAL(rc == 0);
 	CU_ASSERT(g_lvol != NULL);
 	CU_ASSERT(g_lvolerrno == 0);
+	CU_ASSERT(g_snapshot_xattr_called == false);
+
+	/* Snap create with NULL xattrs and xattrs number > 0 */
+	g_lvol = NULL;
+	vbdev_lvol_create_snapshot(lvol, "snap2", NULL, 2,
+				   vbdev_lvol_create_complete, NULL);
+	CU_ASSERT(g_lvol == NULL);
+	CU_ASSERT(g_lvolerrno == -EINVAL);
+
+	/* Snap create with valid xattrs and 0 xattrs number */
+	vbdev_lvol_create_snapshot(lvol, "snap2", (const char *const *)&xattrs, 0,
+				   vbdev_lvol_create_complete, NULL);
+	CU_ASSERT(g_lvol == NULL);
+	CU_ASSERT(g_lvolerrno == -EINVAL);
+
+	/* Successful snap create with xattr */
+	vbdev_lvol_create_snapshot(lvol, "snap4", (const char *const *)&xattrs, 2,
+				   vbdev_lvol_create_complete, NULL);
+	CU_ASSERT(g_lvol != NULL);
+	CU_ASSERT(g_lvolerrno == 0);
+	CU_ASSERT(g_snapshot_xattr_called == true);
 
 	/* Successful lvol destroy */
 	vbdev_lvol_destroy(g_lvol, lvol_store_op_complete, NULL);
@@ -1145,7 +1170,7 @@ ut_lvol_clone(void)
 	lvol = g_lvol;
 
 	/* Successful snap create */
-	vbdev_lvol_create_snapshot(lvol, "snap", vbdev_lvol_create_complete, NULL);
+	vbdev_lvol_create_snapshot(lvol, "snap", NULL, 0, vbdev_lvol_create_complete, NULL);
 	SPDK_CU_ASSERT_FATAL(rc == 0);
 	SPDK_CU_ASSERT_FATAL(g_lvol != NULL);
 	CU_ASSERT(g_lvolerrno == 0);

--- a/test/unit/lib/bdev/vbdev_lvol.c/vbdev_lvol_ut.c
+++ b/test/unit/lib/bdev/vbdev_lvol.c/vbdev_lvol_ut.c
@@ -882,6 +882,13 @@ spdk_lvol_create_snapshot(struct spdk_lvol *lvol, const char *snapshot_name,
 }
 
 void
+spdk_lvol_create_snapshot_with_xattrs(struct spdk_lvol *lvol, const char *snapshot_name,
+				      const char *const *xattrs, size_t xattrs_num,
+				      spdk_lvol_op_with_handle_complete cb_fn, void *cb_arg)
+{
+}
+
+void
 spdk_lvol_create_clone(struct spdk_lvol *lvol, const char *clone_name,
 		       spdk_lvol_op_with_handle_complete cb_fn, void *cb_arg)
 {

--- a/test/unit/lib/lvol/lvol.c/lvol_ut.c
+++ b/test/unit/lib/lvol/lvol.c/lvol_ut.c
@@ -1626,6 +1626,98 @@ lvol_snapshot_fail(void)
 }
 
 static void
+lvol_snapshot_xattr(void)
+{
+	struct lvol_ut_bs_dev dev;
+	struct spdk_lvol *lvol, *snap;
+	struct spdk_lvs_opts opts;
+	int rc = 0;
+	char *xattrs[] = {"snapshot_timestamp", "2024-01-16T16:06:46Z", "user_created", "true"};
+	char *xattrs_bad[] = {"snapshot_timestamp"};
+	const char *value = NULL;
+	size_t value_len = 0;
+	struct xattrs_ctx xattr_ctx;
+
+	init_dev(&dev);
+
+	spdk_lvs_opts_init(&opts);
+	snprintf(opts.name, sizeof(opts.name), "lvs");
+
+	g_lvserrno = -1;
+	rc = spdk_lvs_init(&dev.bs_dev, &opts, lvol_store_op_with_handle_complete, NULL);
+	CU_ASSERT(rc == 0);
+	CU_ASSERT(g_lvserrno == 0);
+	SPDK_CU_ASSERT_FATAL(g_lvol_store != NULL);
+
+	spdk_lvol_create(g_lvol_store, "lvol", 10, true, LVOL_CLEAR_WITH_DEFAULT,
+			 lvol_op_with_handle_complete, NULL);
+	CU_ASSERT(g_lvserrno == 0);
+	SPDK_CU_ASSERT_FATAL(g_lvol != NULL);
+
+	lvol = g_lvol;
+
+	/* Without xattrs, fallback over spdk_lvol_create_snapshot */
+	spdk_lvol_create_snapshot_with_xattrs(lvol, "snap", NULL, 0, lvol_op_with_handle_complete, NULL);
+	CU_ASSERT(g_lvserrno == 0);
+	SPDK_CU_ASSERT_FATAL(g_lvol != NULL);
+	CU_ASSERT_STRING_EQUAL(g_lvol->name, "snap");
+
+	snap = g_lvol;
+
+	/* Should be able to look up name */
+	xattr_ctx.newlvol = lvol;
+	xattr_ctx.xattrs_external = (char **)&xattrs;
+	lvol_get_xattr_value_ext(&xattr_ctx, "name", (const void **)&value, &value_len);
+	CU_ASSERT(value != NULL && strcmp(value, "lvol") == 0);
+	CU_ASSERT(value_len != 0);
+
+	/* With a bad xattrs list */
+	g_lvol = NULL;
+	spdk_lvol_create_snapshot_with_xattrs(lvol, "snap_x", (const char *const *)&xattrs_bad, 1,
+					      lvol_op_with_handle_complete, NULL);
+	CU_ASSERT(g_lvserrno == -EINVAL);
+	CU_ASSERT(g_lvol == NULL);
+
+	/* With a valid xattr list */
+	spdk_lvol_create_snapshot_with_xattrs(lvol, "snap_x", (const char *const *)&xattrs, 4,
+					      lvol_op_with_handle_complete, NULL);
+	CU_ASSERT(g_lvserrno == 0);
+	CU_ASSERT(g_lvol != NULL);
+	CU_ASSERT_STRING_EQUAL(g_lvol->name, "snap_x");
+
+	/* Should be able to look up name, snapshot_timestamp and user_created */
+	lvol_get_xattr_value_ext(&xattr_ctx, "name", (const void **)&value, &value_len);
+	CU_ASSERT(value != NULL && strcmp(value, "lvol") == 0);
+	CU_ASSERT(value_len != 0);
+	lvol_get_xattr_value_ext(&xattr_ctx, "snapshot_timestamp", (const void **)&value, &value_len);
+	CU_ASSERT(value != NULL && strcmp(value, "2024-01-16T16:06:46Z") == 0);
+	CU_ASSERT(value_len != 0);
+	lvol_get_xattr_value_ext(&xattr_ctx, "user_created", (const void **)&value, &value_len);
+	CU_ASSERT(value != NULL && strcmp(value, "true") == 0);
+	CU_ASSERT(value_len != 0);
+
+	/* Lvols has to be closed (or destroyed) before unloading lvol store. */
+	spdk_lvol_close(g_lvol, op_complete, NULL);
+	CU_ASSERT(g_lvserrno == 0);
+	g_lvserrno = -1;
+
+	spdk_lvol_close(snap, op_complete, NULL);
+	CU_ASSERT(g_lvserrno == 0);
+	g_lvserrno = -1;
+
+	spdk_lvol_close(lvol, op_complete, NULL);
+	CU_ASSERT(g_lvserrno == 0);
+	g_lvserrno = -1;
+
+	rc = spdk_lvs_unload(g_lvol_store, op_complete, NULL);
+	CU_ASSERT(rc == 0);
+	CU_ASSERT(g_lvserrno == 0);
+	g_lvol_store = NULL;
+
+	free_dev(&dev);
+}
+
+static void
 lvol_clone(void)
 {
 	struct lvol_ut_bs_dev dev;
@@ -3582,6 +3674,7 @@ main(int argc, char **argv)
 	CU_ADD_TEST(suite, lvol_open);
 	CU_ADD_TEST(suite, lvol_snapshot);
 	CU_ADD_TEST(suite, lvol_snapshot_fail);
+	CU_ADD_TEST(suite, lvol_snapshot_xattr);
 	CU_ADD_TEST(suite, lvol_clone);
 	CU_ADD_TEST(suite, lvol_clone_fail);
 	CU_ADD_TEST(suite, lvol_iter_clones);


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue #8595

#### What this PR does / why we need it:

Adoption of new SPDK release 24.05

#### Special notes for your reviewer:

Some commits of `longhorn-v24.01` have been skipped:

- shallow copy, we have the upstream version (now async)
- set parent, we have the upstream version
- lvol flush, actually not used (must resolve a memory leak with external snapshot)
- lvol unmap, we have the upstream version (also the decrement of `allocated_cluster_number`)

#### Additional documentation or context

The branch `longhorn/spdk:longhorn-v24.05` has been created from `spdk/spdk:v24.05.x` branch, which has an addtional commit(fix) after the tag 24.05. From the UI I can't create a new branch from a tag, so I had to create from that branch.
