### PR TITLE
raid: add delta bitmap implementation

### DIFF
--- a/doc/jsonrpc.md
+++ b/doc/jsonrpc.md
@@ -11053,6 +11053,7 @@ raid_level              | Required | string      | RAID level
 base_bdevs              | Required | string      | Base bdevs name, whitespace separated list in quotes
 uuid                    | Optional | string      | UUID for this RAID bdev
 superblock              | Optional | boolean     | If set, information about raid bdev will be stored in superblock on each base bdev (default: `false`)
+delta_bitmap            | Optional | boolean     | If set, a delta bitmap for faulty base bdevs will be recorded. @ref bdev_raid_get_base_bdev_delta_bitmap
 
 #### Example
 
@@ -11218,6 +11219,125 @@ Example request:
   "params": {
     "raid_name": "Raid1",
     "base_name": "Nvme1n1",
+  }
+}
+~~~
+
+Example response:
+
+~~~json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": true
+}
+~~~
+
+### bdev_raid_get_base_bdev_delta_bitmap {#rpc_bdev_raid_get_base_bdev_delta_bitmap}
+
+Get the delta bitmap of a faulty base bdev. A base bdev enter in faulty state when it is removed
+from the raid due to a write I/O error or to the deletion of the corresponding bdev.
+When in faulty state, a delta bitmap is created and updated by every I/O write operations performed over
+the raid. Expired a defined timeout, the delta bitmap is deleted and the base bdev is removed from the
+faulty state so that no sign of this base bdev will remain in the raid.
+In the delta bitmap, every region modified has the corrisponding bit set to 1.
+The delta bitmap is returned as a base64 encoded string, region size is in bytes.
+Before to retrieve the delta bitmap with this rpc, it must be stopped with the rpc @ref bdev_raid_stop_base_bdev_delta_bitmap
+
+#### Parameters
+
+Name                    | Optional | Type        | Description
+----------------------- | -------- | ----------- | -----------
+base_bdev_name          | Required | string      | Base bdev name in RAID
+
+#### Example
+
+Example request:
+
+~~~json
+{
+  "jsonrpc": "2.0",
+  "method": "bdev_raid_get_base_bdev_delta_bitmap",
+  "id": 1,
+  "params": {
+    "name": "base0"
+  }
+}
+~~~
+
+Example response:
+
+~~~json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": [
+    {
+      "region_size": 4194304,
+      "delta_bitmap": "AA=="
+    }
+  ]
+}
+~~~
+
+### bdev_raid_stop_base_bdev_delta_bitmap {#rpc_bdev_raid_stop_base_bdev_delta_bitmap}
+
+Stop the updating of the delta bitmap of a faulty base bdev
+
+#### Parameters
+
+Name                    | Optional | Type        | Description
+----------------------- | -------- | ----------- | -----------
+base_bdev_name          | Required | string      | Base bdev name in RAID
+
+#### Example
+
+Example request:
+
+~~~json
+{
+  "jsonrpc": "2.0",
+  "method": "bdev_raid_stop_base_bdev_delta_bitmap",
+  "id": 1,
+  "params": {
+    "name": "base0"
+  }
+}
+~~~
+
+Example response:
+
+~~~json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": true
+}
+~~~
+
+### bdev_raid_clear_base_bdev_faulty_state {#rpc_bdev_raid_clear_base_bdev_faulty_state}
+
+Clear the faulty state of a base bdev, in the same way it would have been done internally when the
+timeout expire. It can be used to free the slot occupied by the faulty base bdev into the raid to
+add again the same base bdev to the raid.
+
+#### Parameters
+
+Name                    | Optional | Type        | Description
+----------------------- | -------- | ----------- | -----------
+base_bdev_name          | Required | string      | Base bdev name in RAID
+
+#### Example
+
+Example request:
+
+~~~json
+{
+  "jsonrpc": "2.0",
+  "method": "bdev_raid_clear_base_bdev_faulty_state",
+  "id": 1,
+  "params": {
+    "name": "base0"
   }
 }
 ~~~

--- a/module/bdev/raid/bdev_raid.c
+++ b/module/bdev/raid/bdev_raid.c
@@ -12,6 +12,7 @@
 #include "spdk/util.h"
 #include "spdk/json.h"
 #include "spdk/likely.h"
+#include "spdk/bit_array.h"
 
 #define RAID_OFFSET_BLOCKS_INVALID	UINT64_MAX
 #define RAID_BDEV_PROCESS_MAX_QD	16
@@ -383,6 +384,17 @@ raid_bdev_destroy_cb(void *io_device, void *ctx_buf)
 	raid_bdev_ch_process_cleanup(raid_ch);
 }
 
+static void
+raid_bdev_clear_faulty_base_info(struct raid_base_bdev_info *base_info)
+{
+	if (base_info->delta_bitmap != NULL) {
+		spdk_bit_array_free(&base_info->delta_bitmap);
+	}
+	if (base_info->poller != NULL) {
+		spdk_poller_unregister(&base_info->poller);
+	}
+}
+
 /*
  * brief:
  * raid_bdev_cleanup is used to cleanup raid_bdev related data
@@ -405,6 +417,7 @@ raid_bdev_cleanup(struct raid_bdev *raid_bdev)
 	RAID_FOR_EACH_BASE_BDEV(raid_bdev, base_info) {
 		assert(base_info->desc == NULL);
 		free(base_info->name);
+		raid_bdev_clear_faulty_base_info(base_info);
 	}
 
 	TAILQ_REMOVE(&g_raid_bdev_list, raid_bdev, global_link);
@@ -453,8 +466,11 @@ raid_bdev_free_base_bdev_resource(struct raid_base_bdev_info *base_info)
 
 	assert(spdk_get_thread() == spdk_thread_get_app_thread());
 
-	free(base_info->name);
-	base_info->name = NULL;
+	/* Faulty base bdev name will be deleted when the timeout expire and faulty state cleared */
+	if (base_info->state == BASE_BDEV_STATE_NONE) {
+		free(base_info->name);
+		base_info->name = NULL;
+	}
 	if (raid_bdev->state != RAID_BDEV_STATE_CONFIGURING) {
 		spdk_uuid_set_null(&base_info->uuid);
 	}
@@ -473,6 +489,8 @@ raid_bdev_free_base_bdev_resource(struct raid_base_bdev_info *base_info)
 	if (base_info->is_configured) {
 		raid_bdev_deconfigure_base_bdev(base_info);
 	}
+
+	raid_bdev_clear_faulty_base_info(base_info);
 }
 
 static void
@@ -1090,6 +1108,8 @@ raid_bdev_write_info_json(struct raid_bdev *raid_bdev, struct spdk_json_write_ct
 	spdk_json_write_named_uint32(w, "num_base_bdevs_discovered", raid_bdev->num_base_bdevs_discovered);
 	spdk_json_write_named_uint32(w, "num_base_bdevs_operational",
 				     raid_bdev->num_base_bdevs_operational);
+	spdk_json_write_named_bool(w, "delta_bitmap_enabled", raid_bdev->delta_bitmap_enabled);
+
 	if (raid_bdev->process) {
 		struct raid_bdev_process *process = raid_bdev->process;
 		uint64_t offset = process->window_offset;
@@ -1116,6 +1136,8 @@ raid_bdev_write_info_json(struct raid_bdev *raid_bdev, struct spdk_json_write_ct
 		}
 		spdk_json_write_named_uuid(w, "uuid", &base_info->uuid);
 		spdk_json_write_named_bool(w, "is_configured", base_info->is_configured);
+		spdk_json_write_named_string(w, "delta_bitmap_state",
+					     raid_bdev_delta_bitmap_state(base_info->state));
 		spdk_json_write_named_uint64(w, "data_offset", base_info->data_offset);
 		spdk_json_write_named_uint64(w, "data_size", base_info->data_size);
 		spdk_json_write_object_end(w);
@@ -1307,6 +1329,13 @@ static const char *g_raid_process_type_names[] = {
 	[RAID_PROCESS_MAX]	= NULL
 };
 
+static const char *g_raid_base_delta_bitmap_state[] = {
+	[BASE_BDEV_STATE_NONE]			= "none",
+	[BASE_BDEV_STATE_FAULTY]		= "updating",
+	[BASE_BDEV_STATE_FAULTY_STOPPED]	= "stopped"
+};
+
+
 /* We have to use the typedef in the function declaration to appease astyle. */
 typedef enum raid_level raid_level_t;
 typedef enum raid_bdev_state raid_bdev_state_t;
@@ -1375,6 +1404,16 @@ raid_bdev_process_to_str(enum raid_process_type value)
 	}
 
 	return g_raid_process_type_names[value];
+}
+
+const char *
+raid_bdev_delta_bitmap_state(enum base_bdev_state value)
+{
+	if (value > BASE_BDEV_STATE_FAULTY_STOPPED) {
+		return "";
+	}
+
+	return g_raid_base_delta_bitmap_state[value];
 }
 
 /*
@@ -1482,7 +1521,7 @@ raid_bdev_init(void)
 static int
 _raid_bdev_create(const char *name, uint32_t strip_size, uint8_t num_base_bdevs,
 		  enum raid_level level, bool superblock_enabled, const struct spdk_uuid *uuid,
-		  struct raid_bdev **raid_bdev_out)
+		  bool delta_bitmap_enabled, struct raid_bdev **raid_bdev_out)
 {
 	struct raid_bdev *raid_bdev;
 	struct spdk_bdev *raid_bdev_gen;
@@ -1507,6 +1546,11 @@ _raid_bdev_create(const char *name, uint32_t strip_size, uint8_t num_base_bdevs,
 		}
 	} else if (spdk_u32_is_pow2(strip_size) == false) {
 		SPDK_ERRLOG("Invalid strip size %" PRIu32 "\n", strip_size);
+		return -EINVAL;
+	}
+
+	if (level != RAID1 && delta_bitmap_enabled) {
+		SPDK_ERRLOG("Delta bitmap is supported only by raid1\n");
 		return -EINVAL;
 	}
 
@@ -1561,6 +1605,7 @@ _raid_bdev_create(const char *name, uint32_t strip_size, uint8_t num_base_bdevs,
 	raid_bdev->level = level;
 	raid_bdev->min_base_bdevs_operational = min_operational;
 	raid_bdev->superblock_enabled = superblock_enabled;
+	raid_bdev->delta_bitmap_enabled = delta_bitmap_enabled;
 
 	raid_bdev_gen = &raid_bdev->bdev;
 
@@ -1603,7 +1648,7 @@ _raid_bdev_create(const char *name, uint32_t strip_size, uint8_t num_base_bdevs,
 int
 raid_bdev_create(const char *name, uint32_t strip_size, uint8_t num_base_bdevs,
 		 enum raid_level level, bool superblock_enabled, const struct spdk_uuid *uuid,
-		 struct raid_bdev **raid_bdev_out)
+		 bool delta_bitmap_enabled, struct raid_bdev **raid_bdev_out)
 {
 	struct raid_bdev *raid_bdev;
 	int rc;
@@ -1611,7 +1656,7 @@ raid_bdev_create(const char *name, uint32_t strip_size, uint8_t num_base_bdevs,
 	assert(uuid != NULL);
 
 	rc = _raid_bdev_create(name, strip_size, num_base_bdevs, level, superblock_enabled, uuid,
-			       &raid_bdev);
+			       delta_bitmap_enabled, &raid_bdev);
 	if (rc != 0) {
 		return rc;
 	}
@@ -1872,7 +1917,7 @@ raid_bdev_deconfigure(struct raid_bdev *raid_bdev, raid_bdev_destruct_cb cb_fn,
  * returns:
  * base bdev info if found, otherwise NULL.
  */
-static struct raid_base_bdev_info *
+struct raid_base_bdev_info *
 raid_bdev_find_base_info_by_bdev(struct spdk_bdev *base_bdev)
 {
 	struct raid_bdev *raid_bdev;
@@ -1882,6 +1927,32 @@ raid_bdev_find_base_info_by_bdev(struct spdk_bdev *base_bdev)
 		RAID_FOR_EACH_BASE_BDEV(raid_bdev, base_info) {
 			if (base_info->desc != NULL &&
 			    spdk_bdev_desc_get_bdev(base_info->desc) == base_bdev) {
+				return base_info;
+			}
+		}
+	}
+
+	return NULL;
+}
+
+/*
+ * brief:
+ * raid_bdev_find_base_info_by_bdev function finds the base bdev info of a faulty base bdev by name.
+ * params:
+ * base_bdev_name - base bdev name
+ * returns:
+ * base bdev info if found, otherwise NULL.
+ */
+struct raid_base_bdev_info *
+raid_bdev_find_faulty_base_info_by_name(char *base_bdev_name)
+{
+	struct raid_bdev *raid_bdev;
+	struct raid_base_bdev_info *base_info;
+
+	TAILQ_FOREACH(raid_bdev, &g_raid_bdev_list, global_link) {
+		RAID_FOR_EACH_BASE_BDEV(raid_bdev, base_info) {
+			if (base_info->state != BASE_BDEV_STATE_NONE &&
+			    strcmp(base_info->name, base_bdev_name) == 0) {
 				return base_info;
 			}
 		}
@@ -1957,8 +2028,12 @@ raid_bdev_channels_remove_base_bdev_done(struct spdk_io_channel_iter *i, int sta
 
 	raid_bdev_free_base_bdev_resource(base_info);
 
-	spdk_bdev_unquiesce(&raid_bdev->bdev, &g_raid_if, raid_bdev_remove_base_bdev_on_unquiesced,
-			    base_info);
+	if (base_info->state == BASE_BDEV_STATE_NONE) {
+		spdk_bdev_unquiesce(&raid_bdev->bdev, &g_raid_if, raid_bdev_remove_base_bdev_on_unquiesced,
+				    base_info);
+	} else {
+		raid_bdev_remove_base_bdev_on_unquiesced(base_info, 0);
+	}
 }
 
 static void
@@ -2196,6 +2271,381 @@ _raid_bdev_remove_base_bdev(struct raid_base_bdev_info *base_info,
 	return ret;
 }
 
+struct raid_bdev_delta_bitmap_ctx {
+	struct raid_base_bdev_info *base_info;
+	int status;
+	raid_bdev_destruct_cb cb_fn;
+	void *cb_arg;
+};
+
+static void
+raid_bdev_channel_clear_faulty_state_done(struct spdk_io_channel_iter *i, int status)
+{
+	struct raid_bdev_delta_bitmap_ctx *ctx = spdk_io_channel_iter_get_ctx(i);
+
+	ctx->status = status;
+	if (ctx->cb_fn != NULL) {
+		ctx->cb_fn(ctx->cb_arg, ctx->status);
+	}
+
+	free(ctx);
+}
+
+static void
+raid_bdev_channel_clear_faulty_state(struct spdk_io_channel_iter *i)
+{
+	struct spdk_io_channel *ch = spdk_io_channel_iter_get_channel(i);
+	struct raid_bdev_io_channel *raid_ch = spdk_io_channel_get_ctx(ch);
+	struct raid_bdev_delta_bitmap_ctx *ctx = spdk_io_channel_iter_get_ctx(i);
+	struct raid_base_bdev_info *base_info = ctx->base_info;
+	int rc = 0;
+
+	rc = base_info->raid_bdev->module->channel_faulty_base_bdev(base_info, raid_ch,
+			BASE_BDEV_STATE_NONE);
+
+	spdk_for_each_channel_continue(i, rc);
+}
+
+static int
+_raid_bdev_base_bdev_clear_faulty_state(void *arg, raid_bdev_destruct_cb cb_fn, void *cb_arg)
+{
+	struct raid_base_bdev_info *base_info = arg;
+	struct raid_bdev_delta_bitmap_ctx *ctx;
+	struct raid_bdev *raid_bdev;
+
+	assert(base_info != NULL);
+
+	ctx = calloc(1, sizeof(*ctx));
+	if (ctx == NULL) {
+		SPDK_ERRLOG("Unable to allocate memory for clear faulty state context of base bdev %s\n",
+			    base_info->name);
+		return -ENOMEM;
+	}
+
+
+	base_info->state = BASE_BDEV_STATE_NONE;
+	free(base_info->name);
+	base_info->name = NULL;
+	raid_bdev_clear_faulty_base_info(base_info);
+
+	ctx->base_info = base_info;
+	ctx->cb_fn = cb_fn;
+	ctx->cb_arg = cb_arg;
+
+	raid_bdev = base_info->raid_bdev;
+	spdk_for_each_channel(raid_bdev, raid_bdev_channel_clear_faulty_state, ctx,
+			      raid_bdev_channel_clear_faulty_state_done);
+
+	return 0;
+}
+
+static int
+_raid_bdev_base_bdev_clear_faulty_state_poller(void *arg)
+{
+	struct raid_base_bdev_info *base_info = arg;
+	uint64_t timeout_ticks;
+
+	/* Check if timeout expired */
+	timeout_ticks = base_info->poller_start_ticks + 600 * spdk_get_ticks_hz();
+	if (spdk_get_ticks() < timeout_ticks) {
+		return SPDK_POLLER_IDLE;
+	}
+
+	_raid_bdev_base_bdev_clear_faulty_state(base_info, NULL, NULL);
+
+	return SPDK_POLLER_BUSY;
+}
+
+static void
+raid_bdev_start_faulty_state_on_unquiesced(void *ctx, int status)
+{
+	struct raid_bdev_delta_bitmap_ctx *start_ctx = ctx;
+	struct raid_base_bdev_info *base_info = start_ctx->base_info;
+	struct raid_bdev *raid_bdev = base_info->raid_bdev;
+
+	if (status != 0 || start_ctx->status != 0) {
+		if (status != 0) {
+			SPDK_ERRLOG("Starting faulty state of base bdev %s, failed to unquiesce raid bdev %s: %s\n",
+				    base_info->name, raid_bdev->bdev.name, spdk_strerror(-status));
+		} else {
+			SPDK_ERRLOG("Failed to start faulty state of base bdev %s: %s\n",
+				    base_info->name, spdk_strerror(-start_ctx->status));
+		}
+		_raid_bdev_base_bdev_clear_faulty_state(base_info, NULL, NULL);
+	} else {
+		base_info->poller_start_ticks = spdk_get_ticks();
+		base_info->poller = SPDK_POLLER_REGISTER(_raid_bdev_base_bdev_clear_faulty_state_poller, base_info,
+				    1000000);
+	}
+
+	free(start_ctx);
+}
+
+static void
+raid_bdev_channel_start_faulty_state_done(struct spdk_io_channel_iter *i, int status)
+{
+	struct raid_bdev_delta_bitmap_ctx *ctx = spdk_io_channel_iter_get_ctx(i);
+	struct raid_base_bdev_info *base_info = ctx->base_info;
+	int rc;
+
+	if (status) {
+		ctx->status = status;
+	}
+
+	rc = spdk_bdev_unquiesce(&base_info->raid_bdev->bdev, &g_raid_if,
+				 raid_bdev_start_faulty_state_on_unquiesced,
+				 ctx);
+	if (rc != 0) {
+		raid_bdev_start_faulty_state_on_unquiesced(ctx, rc);
+	}
+}
+
+static void
+raid_bdev_channel_start_faulty_state(struct spdk_io_channel_iter *i)
+{
+	struct spdk_io_channel *ch = spdk_io_channel_iter_get_channel(i);
+	struct raid_bdev_io_channel *raid_ch = spdk_io_channel_get_ctx(ch);
+	struct raid_bdev_delta_bitmap_ctx *ctx = spdk_io_channel_iter_get_ctx(i);
+	struct raid_base_bdev_info *base_info = ctx->base_info;
+	int rc = 0;
+
+	rc = base_info->raid_bdev->module->channel_faulty_base_bdev(base_info, raid_ch,
+			BASE_BDEV_STATE_FAULTY);
+
+	spdk_for_each_channel_continue(i, rc);
+}
+
+static void
+_raid_bdev_start_faulty_state(void *ctx, int status)
+{
+	struct raid_bdev_delta_bitmap_ctx *start_ctx = ctx;
+	struct raid_base_bdev_info *base_info = start_ctx->base_info;
+
+	assert(base_info != NULL);
+
+	if (status != 0) {
+		SPDK_WARNLOG("Failed to remove base bdev %s\n", base_info->name);
+		base_info->is_failed = false;
+		base_info->state = BASE_BDEV_STATE_NONE;
+		free(start_ctx);
+		return;
+	}
+
+	spdk_for_each_channel(base_info->raid_bdev, raid_bdev_channel_start_faulty_state, start_ctx,
+			      raid_bdev_channel_start_faulty_state_done);
+}
+
+static void
+raid_bdev_stop_faulty_state_done(void *_ctx, int status)
+{
+	struct raid_bdev_delta_bitmap_ctx *ctx = _ctx;
+	struct raid_bdev *raid_bdev = ctx->base_info->raid_bdev;
+
+	if (status != 0) {
+		SPDK_ERRLOG("Failed to unquiesce raid bdev %s: %s\n",
+			    raid_bdev->bdev.name, spdk_strerror(-status));
+		ctx->status = status;
+	}
+
+	if (ctx->cb_fn != NULL) {
+		ctx->cb_fn(ctx->cb_arg, ctx->status);
+	}
+
+	free(ctx);
+}
+
+static void
+raid_bdev_channel_stop_faulty_state_done(struct spdk_io_channel_iter *i, int status)
+{
+	struct raid_bdev_delta_bitmap_ctx *ctx = spdk_io_channel_iter_get_ctx(i);
+	struct raid_bdev *raid_bdev = ctx->base_info->raid_bdev;
+
+	ctx->status = status;
+	spdk_bdev_unquiesce(&raid_bdev->bdev, &g_raid_if,
+			    raid_bdev_stop_faulty_state_done, ctx);
+}
+
+static void
+raid_bdev_channel_stop_faulty_state(struct spdk_io_channel_iter *i)
+{
+	struct spdk_io_channel *ch = spdk_io_channel_iter_get_channel(i);
+	struct raid_bdev_io_channel *raid_ch = spdk_io_channel_get_ctx(ch);
+	struct raid_bdev_delta_bitmap_ctx *ctx = spdk_io_channel_iter_get_ctx(i);
+	struct raid_base_bdev_info *base_info = ctx->base_info;
+	int rc = 0;
+
+	rc = base_info->raid_bdev->module->channel_faulty_base_bdev(base_info, raid_ch,
+			BASE_BDEV_STATE_FAULTY_STOPPED);
+
+	spdk_for_each_channel_continue(i, rc);
+}
+
+static void
+_raid_bdev_base_bdev_stop_faulty_state(void *_ctx, int status)
+{
+	struct raid_bdev_delta_bitmap_ctx *ctx = _ctx;
+	struct raid_base_bdev_info *base_info = ctx->base_info;
+	struct raid_bdev *raid_bdev = base_info->raid_bdev;
+
+	if (status != 0) {
+		SPDK_ERRLOG("Failed to quiesce raid bdev %s: %s\n",
+			    raid_bdev->bdev.name, spdk_strerror(-status));
+		raid_bdev_stop_faulty_state_done(ctx, status);
+		return;
+	}
+
+	spdk_for_each_channel(raid_bdev, raid_bdev_channel_stop_faulty_state, ctx,
+			      raid_bdev_channel_stop_faulty_state_done);
+}
+
+/*
+ * brief:
+ * raid_bdev_stop_base_bdev_delta_bitmap function is the method to stop the updating of the delta
+ * bitmap for a faulty base bdev.
+ * If the base bdev is not part of any raid, or if the base bdev is not in faulty state, false is
+ * returned.
+ * params:
+ * base_bdev_name - name of the base bdev
+ * returns:
+ * true - success
+ * false - failure
+ */
+int
+raid_bdev_stop_base_bdev_delta_bitmap(char *base_bdev_name, raid_bdev_destruct_cb cb_fn,
+				      void *cb_arg)
+{
+	struct raid_bdev_delta_bitmap_ctx *ctx;
+	struct raid_base_bdev_info *base_info;
+	struct raid_bdev *raid_bdev;
+	struct spdk_bdev *bdev;
+
+	assert(spdk_get_thread() == spdk_thread_get_app_thread());
+
+	base_info = raid_bdev_find_faulty_base_info_by_name(base_bdev_name);
+
+	if (!base_info) {
+		SPDK_ERRLOG("bdev '%s' not a faulty base info of any RAID\n", base_bdev_name);
+		return -ENODEV;
+	}
+
+	if (base_info->state == BASE_BDEV_STATE_FAULTY_STOPPED) {
+		SPDK_ERRLOG("Delta bitmap of base bdev %s already stopped\n", base_bdev_name);
+		return -EEXIST;
+	}
+
+	ctx = calloc(1, sizeof(*ctx));
+	if (ctx == NULL) {
+		SPDK_ERRLOG("Unable to allocate memory for delta bitmap stop context of base bdev %s\n",
+			    base_bdev_name);
+		return -ENOMEM;
+	}
+
+	raid_bdev = base_info->raid_bdev;
+	bdev = &raid_bdev->bdev;
+	base_info->delta_bitmap = spdk_bit_array_create(raid_bdev_delta_bitmap_region_blocks_number(bdev));
+	if (!base_info->delta_bitmap) {
+		SPDK_ERRLOG("Unable to allocate delta bitmap for base bdev %s\n", base_bdev_name);
+		return -ENOMEM;
+	}
+
+	base_info->state = BASE_BDEV_STATE_FAULTY_STOPPED;
+
+	ctx->base_info = base_info;
+	ctx->cb_fn = cb_fn;
+	ctx->cb_arg = cb_arg;
+
+	return spdk_bdev_quiesce(bdev, &g_raid_if, _raid_bdev_base_bdev_stop_faulty_state, ctx);
+}
+
+/*
+ * brief:
+ * raid_bdev_get_base_bdev_delta_bitmap function is the method to get the delta map of a base bdev that is
+ * in faulty state.
+ * If the base bdev is not part of any raid, or if the base bdev is not in faulty state, NULL is returned.
+ * params:
+ * base_bdev_name - name of the base bdev
+ * returns:
+ * delta map - success
+ * NULL - failure
+ */
+struct spdk_bit_array *raid_bdev_get_base_bdev_delta_bitmap(char *base_bdev_name)
+{
+	struct raid_base_bdev_info *base_info;
+
+	assert(spdk_get_thread() == spdk_thread_get_app_thread());
+
+	base_info = raid_bdev_find_faulty_base_info_by_name(base_bdev_name);
+
+	if (!base_info) {
+		SPDK_ERRLOG("bdev '%s' not a faulty base info of any RAID\n", base_bdev_name);
+		return NULL;
+	}
+
+	if (base_info->state != BASE_BDEV_STATE_FAULTY_STOPPED) {
+		SPDK_ERRLOG("Delta bitmap of base bdev '%s' is not stopped\n", base_bdev_name);
+		return NULL;
+	}
+
+	return base_info->delta_bitmap;
+}
+
+/*
+ * brief:
+ * raid_bdev_clear_base_bdev_faulty_state function is the method to clear the faulty state of a
+ * base bdev and so to delete the delta bitmap.
+ * If the base bdev is not part of any raid, or if the base bdev is not in faulty state, false is
+ * returned.
+ * params:
+ * base_bdev_name - name of the base bdev
+ * returns:
+ * true - success
+ * false - failure
+ */
+int
+raid_bdev_clear_base_bdev_faulty_state(char *base_bdev_name, raid_bdev_destruct_cb cb_fn,
+				       void *cb_arg)
+{
+	struct raid_base_bdev_info *base_info;
+	int rc;
+
+	assert(spdk_get_thread() == spdk_thread_get_app_thread());
+
+	base_info = raid_bdev_find_faulty_base_info_by_name(base_bdev_name);
+
+	if (!base_info) {
+		SPDK_ERRLOG("bdev '%s' not a faulty base info of any RAID\n", base_bdev_name);
+		return -ENODEV;
+	}
+
+	if (base_info->state == BASE_BDEV_STATE_NONE) {
+		SPDK_ERRLOG("Base bdev %s not in faulty state", base_bdev_name);
+		return -EPERM;
+	}
+
+	rc = _raid_bdev_base_bdev_clear_faulty_state(base_info, cb_fn, cb_arg);
+
+	return rc;
+}
+
+uint64_t
+raid_bdev_region_size_base_bdev_delta_bitmap(char *base_bdev_name)
+{
+	struct raid_base_bdev_info *base_info;
+	struct spdk_bdev *bdev;
+
+	assert(spdk_get_thread() == spdk_thread_get_app_thread());
+
+	base_info = raid_bdev_find_faulty_base_info_by_name(base_bdev_name);
+
+	if (!base_info) {
+		SPDK_ERRLOG("bdev '%s' not a faulty base info of any RAID\n", base_bdev_name);
+		return 0;
+	}
+
+	bdev = &base_info->raid_bdev->bdev;
+	return bdev->optimal_io_boundary * bdev->blocklen;
+}
+
 /*
  * brief:
  * raid_bdev_remove_base_bdev function is called by below layers when base_bdev
@@ -2224,6 +2674,42 @@ raid_bdev_remove_base_bdev(struct spdk_bdev *base_bdev, raid_base_bdev_cb cb_fn,
 	return _raid_bdev_remove_base_bdev(base_info, cb_fn, cb_ctx);
 }
 
+static int
+raid_bdev_start_faulty_state(struct raid_base_bdev_info *base_info)
+{
+	struct raid_bdev_delta_bitmap_ctx *ctx;
+	raid_base_bdev_cb cb_fn = NULL;
+	void *cb_ctx = NULL;
+	int rc;
+
+	if (base_info->raid_bdev->delta_bitmap_enabled) {
+		ctx = calloc(1, sizeof(*ctx));
+		if (ctx == NULL) {
+			SPDK_ERRLOG("Unable to allocate memory for delta bitmap start context of base bdev %s\n",
+				    base_info->name);
+			return -ENOMEM;
+		}
+
+		ctx->base_info = base_info;
+
+		/*
+		 * It is necessary to set here the faulty state, otherwise base info name will be freed
+		 * by _raid_bdev_remove_base_bdev
+		 */
+		base_info->state = BASE_BDEV_STATE_FAULTY;
+		cb_fn = _raid_bdev_start_faulty_state;
+		cb_ctx = ctx;
+	}
+
+	rc = _raid_bdev_remove_base_bdev(base_info, cb_fn, cb_ctx);
+	if (rc != 0) {
+		SPDK_ERRLOG("Failed to remove base bdev %s: %s\n",
+			    base_info->name, spdk_strerror(-rc));
+	}
+
+	return rc;
+}
+
 static void
 raid_bdev_fail_base_remove_cb(void *ctx, int status)
 {
@@ -2249,7 +2735,7 @@ _raid_bdev_fail_base_bdev(void *ctx)
 	SPDK_NOTICELOG("Failing base bdev in slot %d ('%s') of raid bdev '%s'\n",
 		       raid_bdev_base_bdev_slot(base_info), base_info->name, base_info->raid_bdev->bdev.name);
 
-	rc = _raid_bdev_remove_base_bdev(base_info, raid_bdev_fail_base_remove_cb, base_info);
+	rc = raid_bdev_start_faulty_state(base_info);
 	if (rc != 0) {
 		raid_bdev_fail_base_remove_cb(base_info, rc);
 	}
@@ -2334,6 +2820,26 @@ raid_bdev_resize_base_bdev(struct spdk_bdev *base_bdev)
 	}
 }
 
+static void
+raid_bdev_event_remove_base_bdev(struct spdk_bdev *bdev)
+{
+	struct raid_base_bdev_info *base_info;
+	int rc;
+
+	/* Find the base bdev info which this bdev belongs to */
+	base_info = raid_bdev_find_base_info_by_bdev(bdev);
+	if (!base_info) {
+		SPDK_ERRLOG("bdev to remove '%s' not found\n", bdev->name);
+		return;
+	}
+
+	rc = raid_bdev_start_faulty_state(base_info);
+	if (rc != 0) {
+		SPDK_ERRLOG("Failed to remove base bdev %s: %s\n",
+			    spdk_bdev_get_name(bdev), spdk_strerror(-rc));
+	}
+}
+
 /*
  * brief:
  * raid_bdev_event_base_bdev function is called by below layers when base_bdev
@@ -2349,15 +2855,9 @@ static void
 raid_bdev_event_base_bdev(enum spdk_bdev_event_type type, struct spdk_bdev *bdev,
 			  void *event_ctx)
 {
-	int rc;
-
 	switch (type) {
 	case SPDK_BDEV_EVENT_REMOVE:
-		rc = raid_bdev_remove_base_bdev(bdev, NULL, NULL);
-		if (rc != 0) {
-			SPDK_ERRLOG("Failed to remove base bdev %s: %s\n",
-				    spdk_bdev_get_name(bdev), spdk_strerror(-rc));
-		}
+		raid_bdev_event_remove_base_bdev(bdev);
 		break;
 	case SPDK_BDEV_EVENT_RESIZE:
 		raid_bdev_resize_base_bdev(bdev);
@@ -3367,9 +3867,16 @@ raid_bdev_add_base_bdev(struct raid_bdev *raid_bdev, const char *name,
 
 	if (base_info == NULL || raid_bdev->state == RAID_BDEV_STATE_ONLINE) {
 		RAID_FOR_EACH_BASE_BDEV(raid_bdev, iter) {
-			if (iter->name == NULL && spdk_uuid_is_null(&iter->uuid)) {
+			if (iter->name == NULL && spdk_uuid_is_null(&iter->uuid) && iter->state == BASE_BDEV_STATE_NONE) {
 				base_info = iter;
 				break;
+			}
+
+			/* Check if a faulty base bdev with the same name is present */
+			if (iter->state != BASE_BDEV_STATE_NONE && strcmp(iter->name, name) == 0) {
+				SPDK_ERRLOG("Base bdev %s is in faulty state, clear this state before to add\n",
+					    name);
+				return -EBUSY;
 			}
 		}
 	}
@@ -3584,18 +4091,27 @@ raid_bdev_grow_base_bdev_on_added(void *_ctx, int status)
 }
 
 static int
-raid_bdev_grow_base_bdev_get_slot(struct raid_bdev *raid_bdev, uint8_t *slot)
+raid_bdev_grow_base_bdev_get_slot(struct raid_bdev *raid_bdev, char *base_bdev_name, uint8_t *slot)
 {
 	uint8_t num_base_bdevs = raid_bdev->num_base_bdevs;
 	struct raid_base_bdev_info *base_info = NULL;
 	void *tmp;
 	int i;
 
-	/* Check for free slot, because a previous remove operation could have created an hole */
+	/*
+	 * Check for free slot, because a previous remove operation could have created an hole
+	 * Must skip a free slot that is still reserved for a faulty base bdev
+	 */
 	for (i = 0; i < raid_bdev->num_base_bdevs; i++) {
 		base_info = &raid_bdev->base_bdev_info[i];
-		if (base_info->name == NULL) {
+		if (base_info->desc == NULL && base_info->state == BASE_BDEV_STATE_NONE) {
 			break;
+		}
+		/* Check if a faulty base bdev with the same name is present */
+		if (base_info->state != BASE_BDEV_STATE_NONE && strcmp(base_info->name, base_bdev_name) == 0) {
+			SPDK_ERRLOG("Base bdev %s is in faulty state, clear this state before to grow\n",
+				    base_bdev_name);
+			return -EBUSY;
 		}
 	}
 
@@ -3610,7 +4126,7 @@ raid_bdev_grow_base_bdev_get_slot(struct raid_bdev *raid_bdev, uint8_t *slot)
 
 		tmp = realloc(raid_bdev->base_bdev_info, num_base_bdevs * sizeof(*raid_bdev->base_bdev_info));
 		if (tmp == NULL) {
-			SPDK_ERRLOG("Unable able to reallocate base bdev info\n");
+			SPDK_ERRLOG("Unable to reallocate base bdev info\n");
 			return -ENOMEM;
 		}
 		memset(tmp + raid_bdev->num_base_bdevs * sizeof(*raid_bdev->base_bdev_info), 0,
@@ -3645,7 +4161,7 @@ raid_bdev_grow_base_bdev_on_quiesced(void *_ctx, int status)
 		return;
 	}
 
-	rc = raid_bdev_grow_base_bdev_get_slot(ctx->raid_bdev, &ctx->slot);
+	rc = raid_bdev_grow_base_bdev_get_slot(ctx->raid_bdev, ctx->base_bdev_name, &ctx->slot);
 	if (rc != 0) {
 		goto err;
 	}
@@ -3783,7 +4299,7 @@ raid_bdev_create_from_sb(const struct raid_bdev_superblock *sb, struct raid_bdev
 	int rc;
 
 	rc = _raid_bdev_create(sb->name, (sb->strip_size * sb->block_size) / 1024, sb->num_base_bdevs,
-			       sb->level, true, &sb->uuid, &raid_bdev);
+			       sb->level, true, &sb->uuid, sb->delta_bitmap_enabled, &raid_bdev);
 	if (rc != 0) {
 		return rc;
 	}

--- a/module/bdev/raid/bdev_raid.h
+++ b/module/bdev/raid/bdev_raid.h
@@ -43,6 +43,25 @@ enum raid_bdev_state {
 	RAID_BDEV_STATE_MAX
 };
 
+/*
+ * The state of a base bdev
+ * When a bdev remove event or a base bdev fail message arrive to the raid, if delta map is enabled,
+ * the base bdev enter in faulty state for a defined timeout: the base bdev is removed from the
+ * raid but a delta bitmap is created and updated by every I/O write operations performed over the raid.
+ * Expired the timeout, the delta bitmap is deleted and the base bdev is removed from the faulty state,
+ * so no sign of this base bdev will remain in the raid.
+ */
+enum base_bdev_state {
+	/* The base bdev is healthy */
+	BASE_BDEV_STATE_NONE,
+
+	/* The faulty timer is running and the delta bitmap is being updated */
+	BASE_BDEV_STATE_FAULTY,
+
+	/* The faulty timer is running but the updating of the delta bitmap is stopped */
+	BASE_BDEV_STATE_FAULTY_STOPPED
+};
+
 enum raid_process_type {
 	RAID_PROCESS_NONE,
 	RAID_PROCESS_REBUILD,
@@ -114,6 +133,26 @@ struct raid_base_bdev_info {
 
 	/* Set to true to skip the start of the rebuild process when adding to an online raid */
 	bool			skip_rebuild;
+
+	/* The state of the base bdev */
+	enum base_bdev_state	state;
+
+	/*
+	 * When the base bdev is in faulty state, this bitmap records all the regions that have
+	 * been modified by a write operation. Region size is equal to bdev optimal_io_boundary.
+	 * Delta bitmap can be retrieved with a RPC to speed up the rebuild of the base bdev in case
+	 * it come back online before being declared definitely dead and delta_bitmap deleted.
+	 */
+	struct spdk_bit_array	*delta_bitmap;
+
+	/* The poller starts when the base bdev becomes faulty and the delta_bitmap is created.
+	 * When the poller expires, base bdev is definitely removed from the raid and the
+	 * delta bitmap is deleted.
+	 */
+	struct spdk_poller	*poller;
+
+	/* The ticks passed since the start of the poller */
+	uint64_t		poller_start_ticks;
 };
 
 struct raid_bdev_io;
@@ -248,6 +287,9 @@ struct raid_bdev {
 
 	/* A flag to indicate that an operation to add/remove a base bdev is in progress */
 	bool				base_bdev_updating;
+
+	/* A flag to enable the recording of a delta bitmap for faulty base bdevs */
+	bool				delta_bitmap_enabled;
 };
 
 #define RAID_FOR_EACH_BASE_BDEV(r, i) \
@@ -264,7 +306,7 @@ typedef void (*raid_bdev_destruct_cb)(void *cb_ctx, int rc);
 
 int raid_bdev_create(const char *name, uint32_t strip_size, uint8_t num_base_bdevs,
 		     enum raid_level level, bool superblock, const struct spdk_uuid *uuid,
-		     struct raid_bdev **raid_bdev_out);
+		     bool delta_bitmap_enabled, struct raid_bdev **raid_bdev_out);
 void raid_bdev_delete(struct raid_bdev *raid_bdev, raid_bdev_destruct_cb cb_fn, void *cb_ctx);
 int raid_bdev_add_base_bdev(struct raid_bdev *raid_bdev, const char *name,
 			    raid_base_bdev_cb cb_fn, void *cb_ctx);
@@ -278,6 +320,15 @@ void raid_bdev_write_info_json(struct raid_bdev *raid_bdev, struct spdk_json_wri
 int raid_bdev_remove_base_bdev(struct spdk_bdev *base_bdev, raid_base_bdev_cb cb_fn, void *cb_ctx);
 int raid_bdev_grow_base_bdev(struct raid_bdev *raid_bdev, char *base_bdev_name,
 			     raid_bdev_destruct_cb cb_fn, void *cb_arg);
+struct raid_base_bdev_info *raid_bdev_find_base_info_by_bdev(struct spdk_bdev *base_bdev);
+struct raid_base_bdev_info *raid_bdev_find_faulty_base_info_by_name(char *base_bdev_name);
+struct spdk_bit_array *raid_bdev_get_base_bdev_delta_bitmap(char *base_bdev_name);
+int raid_bdev_stop_base_bdev_delta_bitmap(char *base_bdev_name, raid_bdev_destruct_cb cb_fn,
+		void *cb_arg);
+int raid_bdev_clear_base_bdev_faulty_state(char *base_bdev_name, raid_bdev_destruct_cb cb_fn,
+		void *cb_arg);
+uint64_t raid_bdev_region_size_base_bdev_delta_bitmap(char *base_bdev_name);
+const char *raid_bdev_delta_bitmap_state(enum base_bdev_state value);
 
 /*
  * RAID module descriptor
@@ -357,6 +408,11 @@ struct raid_bdev_module {
 	bool (*channel_grow_base_bdev)(struct raid_bdev *raid_bdev,
 				       struct raid_bdev_io_channel *raid_ch);
 
+	/* Handle for module specific operations needed to handle faulty base bdev */
+	int (*channel_faulty_base_bdev)(struct raid_base_bdev_info *base_info,
+					struct raid_bdev_io_channel *raid_ch,
+					enum base_bdev_state newState);
+
 };
 
 void raid_bdev_module_list_add(struct raid_bdev_module *raid_module);
@@ -390,6 +446,13 @@ void raid_bdev_io_init(struct raid_bdev_io *raid_io, struct raid_bdev_io_channel
 		       struct spdk_memory_domain *memory_domain, void *memory_domain_ctx);
 void raid_bdev_fail_base_bdev(struct raid_base_bdev_info *base_info);
 
+/* RAID delta map update message and data */
+struct raid_bdev_io_failed {
+	struct raid_base_bdev_info *base_info;
+	uint64_t offset_blocks;
+	uint64_t num_blocks;
+};
+
 static inline uint8_t
 raid_bdev_base_bdev_slot(struct raid_base_bdev_info *base_info)
 {
@@ -402,6 +465,12 @@ raid_bdev_io_set_default_status(struct raid_bdev_io *raid_io, enum spdk_bdev_io_
 	assert(raid_io->base_bdev_io_submitted == 0);
 	raid_io->base_bdev_io_status = status;
 	raid_io->base_bdev_io_status_default = status;
+}
+
+static inline uint32_t
+raid_bdev_delta_bitmap_region_blocks_number(struct spdk_bdev *bdev_raid)
+{
+	return bdev_raid->blockcnt / bdev_raid->optimal_io_boundary;
 }
 
 int raid_bdev_remap_dix_reftag(void *md_buf, uint64_t num_blocks,
@@ -538,8 +607,10 @@ struct raid_bdev_superblock {
 	uint64_t		seq_number;
 	/* number of raid base devices */
 	uint8_t			num_base_bdevs;
+	/*  */
+	bool			delta_bitmap_enabled;
 
-	uint8_t			reserved[118];
+	uint8_t			reserved[116];
 
 	/* size of the base bdevs array */
 	uint8_t			base_bdevs_size;

--- a/module/bdev/raid/bdev_raid_rpc.c
+++ b/module/bdev/raid/bdev_raid_rpc.c
@@ -10,6 +10,7 @@
 #include "spdk/string.h"
 #include "spdk/log.h"
 #include "spdk/env.h"
+#include "spdk/bit_array.h"
 
 #define RPC_MAX_BASE_BDEVS 255
 
@@ -137,6 +138,9 @@ struct rpc_bdev_raid_create {
 
 	/* If set, information about raid bdev will be stored in superblock on each base bdev */
 	bool                                 superblock_enabled;
+
+	/* Enable the recording of a delta bitmap for faulty base bdevs */
+	bool				     delta_bitmap_enabled;
 };
 
 /*
@@ -184,6 +188,7 @@ static const struct spdk_json_object_decoder rpc_bdev_raid_create_decoders[] = {
 	{"base_bdevs", offsetof(struct rpc_bdev_raid_create, base_bdevs), decode_base_bdevs},
 	{"uuid", offsetof(struct rpc_bdev_raid_create, uuid), spdk_json_decode_uuid, true},
 	{"superblock", offsetof(struct rpc_bdev_raid_create, superblock_enabled), spdk_json_decode_bool, true},
+	{"delta_bitmap", offsetof(struct rpc_bdev_raid_create, delta_bitmap_enabled), spdk_json_decode_bool, true},
 };
 
 struct rpc_bdev_raid_create_ctx {
@@ -288,7 +293,8 @@ rpc_bdev_raid_create(struct spdk_jsonrpc_request *request,
 	}
 
 	rc = raid_bdev_create(req->name, req->strip_size_kb, num_base_bdevs,
-			      req->level, req->superblock_enabled, &req->uuid, &raid_bdev);
+			      req->level, req->superblock_enabled, &req->uuid,
+			      req->delta_bitmap_enabled, &raid_bdev);
 	if (rc != 0) {
 		spdk_jsonrpc_send_error_response_fmt(request, rc,
 						     "Failed to create RAID bdev %s: %s",
@@ -771,3 +777,213 @@ cleanup:
 	free(ctx);
 }
 SPDK_RPC_REGISTER("bdev_raid_grow_base_bdev", rpc_bdev_raid_grow_base_bdev, SPDK_RPC_RUNTIME)
+
+/* delta bitmap */
+
+/* Structure to decode the input parameters for delta bitmap RPC methods. */
+static const struct spdk_json_object_decoder rpc_bdev_raid_base_bdev_delta_bitmap_decoders[] = {
+	{"base_bdev_name", 0, spdk_json_decode_string},
+};
+
+struct rpc_bdev_raid_delta_bitmap_ctx {
+	char *base_bdev_name;
+	struct spdk_jsonrpc_request *request;
+};
+
+static void
+rpc_bdev_raid_get_base_bdev_delta_bitmap(struct spdk_jsonrpc_request *request,
+		const struct spdk_json_val *params)
+{
+	char *base_bdev_name = NULL;
+	struct spdk_json_write_ctx *w;
+	struct spdk_bit_array *delta_bitmap;
+	char *encoded;
+	uint64_t region_size;
+	int rc;
+
+	rc = spdk_json_decode_object(params, rpc_bdev_raid_base_bdev_delta_bitmap_decoders,
+				     SPDK_COUNTOF(rpc_bdev_raid_base_bdev_delta_bitmap_decoders),
+				     &base_bdev_name);
+	if (rc) {
+		spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_PARSE_ERROR,
+						 "spdk_json_decode_object failed");
+		goto cleanup;
+	}
+
+	delta_bitmap = raid_bdev_get_base_bdev_delta_bitmap(base_bdev_name);
+	if (delta_bitmap == NULL) {
+		spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_INVALID_PARAMS,
+						 "Invalid parameters");
+		goto cleanup;
+	}
+
+	encoded = spdk_bit_array_to_base64_string(delta_bitmap);
+	if (encoded == NULL) {
+		SPDK_ERRLOG("Failed to encode delta map to base64 string\n");
+		spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_INTERNAL_ERROR,
+						 spdk_strerror(ENOMEM));
+		goto cleanup;
+	}
+
+	region_size = raid_bdev_region_size_base_bdev_delta_bitmap(base_bdev_name);
+
+	w = spdk_jsonrpc_begin_result(request);
+	spdk_json_write_object_begin(w);
+
+	spdk_json_write_named_uint64(w, "region_size", region_size);
+	spdk_json_write_named_string(w, "delta_bitmap", encoded);
+
+	spdk_json_write_object_end(w);
+	spdk_jsonrpc_end_result(request, w);
+
+	free(encoded);
+
+cleanup:
+	free(base_bdev_name);
+}
+SPDK_RPC_REGISTER("bdev_raid_get_base_bdev_delta_bitmap", rpc_bdev_raid_get_base_bdev_delta_bitmap,
+		  SPDK_RPC_RUNTIME)
+
+/*
+ * brief:
+ * params:
+ * cb_arg - pointer to the callback context.
+ * rc - return code of the delta bitmap stopping.
+ * returns:
+ * none
+ */
+static void
+bdev_raid_stop_base_bdev_delta_bitmap_done(void *cb_arg, int rc)
+{
+	struct rpc_bdev_raid_delta_bitmap_ctx *ctx = cb_arg;
+	struct spdk_jsonrpc_request *request = ctx->request;
+
+	if (rc != 0) {
+		SPDK_ERRLOG("Failed to stop base bdev %s delta map: %s",
+			    ctx->base_bdev_name, spdk_strerror(-rc));
+		spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_INTERNAL_ERROR,
+						 spdk_strerror(-rc));
+		goto exit;
+	}
+
+	spdk_jsonrpc_send_bool_response(request, true);
+exit:
+	free(ctx->base_bdev_name);
+	free(ctx);
+}
+
+static void
+rpc_bdev_raid_stop_base_bdev_delta_bitmap(struct spdk_jsonrpc_request *request,
+		const struct spdk_json_val *params)
+{
+	struct rpc_bdev_raid_delta_bitmap_ctx *ctx;
+	int rc;
+
+	ctx = calloc(1, sizeof(*ctx));
+	if (!ctx) {
+		spdk_jsonrpc_send_error_response(request, -ENOMEM, spdk_strerror(ENOMEM));
+		return;
+	}
+
+	if (spdk_json_decode_object(params, rpc_bdev_raid_base_bdev_delta_bitmap_decoders,
+				    SPDK_COUNTOF(rpc_bdev_raid_base_bdev_delta_bitmap_decoders),
+				    &ctx->base_bdev_name)) {
+		spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_PARSE_ERROR,
+						 "spdk_json_decode_object failed");
+		goto cleanup;
+	}
+
+	ctx->request = request;
+
+	rc = raid_bdev_stop_base_bdev_delta_bitmap(ctx->base_bdev_name,
+			bdev_raid_stop_base_bdev_delta_bitmap_done, ctx);
+	if (rc != 0) {
+		spdk_jsonrpc_send_error_response_fmt(request, rc,
+						     "Failed to stop base bdev %s delta map: %s",
+						     ctx->base_bdev_name, spdk_strerror(-rc));
+		goto cleanup;
+	}
+
+	return;
+
+cleanup:
+	if (ctx->base_bdev_name) {
+		free(ctx->base_bdev_name);
+	}
+	free(ctx);
+}
+SPDK_RPC_REGISTER("bdev_raid_stop_base_bdev_delta_bitmap",
+		  rpc_bdev_raid_stop_base_bdev_delta_bitmap,
+		  SPDK_RPC_RUNTIME)
+
+/*
+ * brief:
+ * params:
+ * cb_arg - pointer to the callback context.
+ * rc - return code of the faulty base bdev clearing.
+ * returns:
+ * none
+ */
+static void
+bdev_raid_clear_base_bdev_faulty_state_done(void *cb_arg, int rc)
+{
+	struct rpc_bdev_raid_delta_bitmap_ctx *ctx = cb_arg;
+	struct spdk_jsonrpc_request *request = ctx->request;
+
+	if (rc != 0) {
+		SPDK_ERRLOG("Failed to clear base bdev %s faulty state: %s",
+			    ctx->base_bdev_name, spdk_strerror(-rc));
+		spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_INTERNAL_ERROR,
+						 spdk_strerror(-rc));
+		goto exit;
+	}
+
+	spdk_jsonrpc_send_bool_response(request, true);
+exit:
+	free(ctx->base_bdev_name);
+	free(ctx);
+}
+
+static void
+rpc_bdev_raid_clear_base_bdev_faulty_state(struct spdk_jsonrpc_request *request,
+		const struct spdk_json_val *params)
+{
+	struct rpc_bdev_raid_delta_bitmap_ctx *ctx;
+	int rc;
+
+	ctx = calloc(1, sizeof(*ctx));
+	if (!ctx) {
+		spdk_jsonrpc_send_error_response(request, -ENOMEM, spdk_strerror(ENOMEM));
+		return;
+	}
+
+	if (spdk_json_decode_object(params, rpc_bdev_raid_base_bdev_delta_bitmap_decoders,
+				    SPDK_COUNTOF(rpc_bdev_raid_base_bdev_delta_bitmap_decoders),
+				    &ctx->base_bdev_name)) {
+		spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_PARSE_ERROR,
+						 "spdk_json_decode_object failed");
+		goto cleanup;
+	}
+
+	ctx->request = request;
+
+	rc = raid_bdev_clear_base_bdev_faulty_state(ctx->base_bdev_name,
+			bdev_raid_clear_base_bdev_faulty_state_done,
+			ctx);
+	if (rc != 0) {
+		spdk_jsonrpc_send_error_response_fmt(request, rc,
+						     "Failed to clear base bdev %s faulty state: %s",
+						     ctx->base_bdev_name, spdk_strerror(-rc));
+		goto cleanup;
+	}
+
+	return;
+
+cleanup:
+	if (ctx->base_bdev_name) {
+		free(ctx->base_bdev_name);
+	}
+	free(ctx);
+}
+SPDK_RPC_REGISTER("bdev_raid_clear_base_bdev_faulty_state",
+		  rpc_bdev_raid_clear_base_bdev_faulty_state, SPDK_RPC_RUNTIME)

--- a/module/bdev/raid/bdev_raid_sb.c
+++ b/module/bdev/raid/bdev_raid_sb.c
@@ -80,6 +80,7 @@ raid_bdev_init_superblock(struct raid_bdev *raid_bdev)
 	/* TODO: sb->state */
 	sb->num_base_bdevs = sb->base_bdevs_size = raid_bdev->num_base_bdevs;
 	sb->length = sizeof(*sb) + sizeof(*sb_base_bdev) * sb->base_bdevs_size;
+	sb->delta_bitmap_enabled = raid_bdev->delta_bitmap_enabled;
 
 	sb_base_bdev = &sb->base_bdevs[0];
 	RAID_FOR_EACH_BASE_BDEV(raid_bdev, base_info) {

--- a/module/bdev/raid/raid1.c
+++ b/module/bdev/raid/raid1.c
@@ -7,6 +7,7 @@
 
 #include "spdk/likely.h"
 #include "spdk/log.h"
+#include "spdk/bit_array.h"
 
 struct raid1_info {
 	/* The parent raid bdev */
@@ -16,7 +17,43 @@ struct raid1_info {
 struct raid1_io_channel {
 	/* Array of per-base_bdev counters of outstanding read blocks on this channel */
 	uint64_t *read_blocks_outstanding;
+
+	/* Array of per-base_bdev delta maps of faulty base bdevs */
+	struct spdk_bit_array **delta_bitmaps;
+
+	/* The state of the base bdev */
+	enum base_bdev_state	*states;
 };
+
+static void
+raid1_handle_faulty_base_bdev(struct raid_bdev_io *raid_io, struct raid_base_bdev_info *base_info)
+{
+	struct spdk_bdev *bdev = &base_info->raid_bdev->bdev;
+	struct raid1_io_channel *raid1_ch = raid_bdev_channel_get_module_ctx(raid_io->raid_ch);
+	uint32_t section_index, start_section, end_section;
+	uint8_t idx = base_info - base_info->raid_bdev->base_bdev_info;
+
+	if (spdk_likely(raid1_ch->states[idx] == BASE_BDEV_STATE_FAULTY) ||
+	    (raid1_ch->states[idx] == BASE_BDEV_STATE_NONE && base_info->raid_bdev->delta_bitmap_enabled)) {
+		start_section = raid_io->offset_blocks / bdev->optimal_io_boundary;
+		end_section = (raid_io->offset_blocks + raid_io->num_blocks) / bdev->optimal_io_boundary;
+
+		if (spdk_unlikely(!raid1_ch->delta_bitmaps[idx])) {
+			raid1_ch->delta_bitmaps[idx] = spdk_bit_array_create(bdev->blockcnt /
+						       bdev->optimal_io_boundary);
+			if (!raid1_ch->delta_bitmaps[idx]) {
+				raid1_ch->states[idx] = BASE_BDEV_STATE_FAULTY_STOPPED;
+				return;
+			}
+
+			raid1_ch->states[idx] = BASE_BDEV_STATE_FAULTY;
+		}
+
+		for (section_index = start_section; section_index <= end_section; section_index++) {
+			spdk_bit_array_set(raid1_ch->delta_bitmaps[idx], section_index);
+		}
+	}
+}
 
 static void
 raid1_channel_inc_read_counters(struct raid_bdev_io_channel *raid_ch, uint8_t idx,
@@ -58,6 +95,7 @@ raid1_write_bdev_io_completion(struct spdk_bdev_io *bdev_io, bool success, void 
 
 		base_info = raid_bdev_channel_get_base_info(raid_io->raid_ch, bdev_io->bdev);
 		if (base_info) {
+			raid1_handle_faulty_base_bdev(raid_io, base_info);
 			raid_bdev_fail_base_bdev(base_info);
 		}
 	}
@@ -85,6 +123,8 @@ raid1_correct_read_error_completion(struct spdk_bdev_io *bdev_io, bool success, 
 
 	if (!success) {
 		struct raid_base_bdev_info *base_info = raid1_get_read_io_base_bdev(raid_io);
+
+		raid1_handle_faulty_base_bdev(raid_io, base_info);
 
 		/* Writing to the bdev that had the read error failed so fail the base bdev
 		 * but complete the raid_io successfully. */
@@ -318,6 +358,9 @@ raid1_submit_write_request(struct raid_bdev_io *raid_io)
 		base_ch = raid_bdev_channel_get_base_channel(raid_io->raid_ch, idx);
 
 		if (base_ch == NULL) {
+			/* If the base bdev is in faulty state, must update the bitmap */
+			raid1_handle_faulty_base_bdev(raid_io, base_info);
+
 			/* skip a missing base bdev's slot */
 			raid_io->base_bdev_io_submitted++;
 			raid_bdev_io_complete_part(raid_io, 1, SPDK_BDEV_IO_STATUS_FAILED);
@@ -465,8 +508,22 @@ static void
 raid1_ioch_destroy(void *io_device, void *ctx_buf)
 {
 	struct raid1_io_channel *r1ch = ctx_buf;
+	struct raid1_info *r1info = io_device;
+	struct raid_bdev *raid_bdev = r1info->raid_bdev;
+	uint8_t i;
 
 	free(r1ch->read_blocks_outstanding);
+
+	if (r1ch->delta_bitmaps) {
+		for (i = 0; i < raid_bdev->num_base_bdevs; i++) {
+			if (r1ch->delta_bitmaps[i]) {
+				spdk_bit_array_free(&r1ch->delta_bitmaps[i]);
+			}
+		}
+		free(r1ch->delta_bitmaps);
+	}
+
+	free(r1ch->states);
 }
 
 static int
@@ -475,16 +532,33 @@ raid1_ioch_create(void *io_device, void *ctx_buf)
 	struct raid1_io_channel *r1ch = ctx_buf;
 	struct raid1_info *r1info = io_device;
 	struct raid_bdev *raid_bdev = r1info->raid_bdev;
-	int ret = 0;
 
 	r1ch->read_blocks_outstanding = calloc(raid_bdev->num_base_bdevs,
 					       sizeof(*r1ch->read_blocks_outstanding));
 	if (!r1ch->read_blocks_outstanding) {
 		SPDK_ERRLOG("Failed to initialize io channel\n");
-		ret = -ENOMEM;
+		return -ENOMEM;
 	}
 
-	return ret;
+	if (raid_bdev->delta_bitmap_enabled) {
+		r1ch->delta_bitmaps = calloc(raid_bdev->num_base_bdevs,
+					     sizeof(*r1ch->delta_bitmaps));
+		if (!r1ch->delta_bitmaps) {
+			SPDK_ERRLOG("Failed to create delta maps initializing io channel\n");
+			free(r1ch->read_blocks_outstanding);
+			return -ENOMEM;
+		}
+	}
+
+	r1ch->states = calloc(raid_bdev->num_base_bdevs, sizeof(*r1ch->states));
+	if (!r1ch->states) {
+		SPDK_ERRLOG("Failed to create states initializing io channel\n");
+		free(r1ch->delta_bitmaps);
+		free(r1ch->read_blocks_outstanding);
+		return -ENOMEM;
+	}
+
+	return 0;
 }
 
 static void
@@ -501,7 +575,9 @@ static int
 raid1_start(struct raid_bdev *raid_bdev)
 {
 	uint64_t min_blockcnt = UINT64_MAX;
+	uint32_t min_optimal_io_boundary = UINT32_MAX;
 	struct raid_base_bdev_info *base_info;
+	struct spdk_bdev *bdev;
 	struct raid1_info *r1info;
 	char name[256];
 
@@ -514,6 +590,11 @@ raid1_start(struct raid_bdev *raid_bdev)
 
 	RAID_FOR_EACH_BASE_BDEV(raid_bdev, base_info) {
 		min_blockcnt = spdk_min(min_blockcnt, base_info->data_size);
+
+		if (base_info->desc != NULL) {
+			bdev = spdk_bdev_desc_get_bdev(base_info->desc);
+			min_optimal_io_boundary = spdk_min(min_optimal_io_boundary, bdev->optimal_io_boundary);
+		}
 	}
 
 	RAID_FOR_EACH_BASE_BDEV(raid_bdev, base_info) {
@@ -521,6 +602,7 @@ raid1_start(struct raid_bdev *raid_bdev)
 	}
 
 	raid_bdev->bdev.blockcnt = min_blockcnt;
+	raid_bdev->bdev.optimal_io_boundary = min_optimal_io_boundary;
 	raid_bdev->module_private = r1info;
 
 	snprintf(name, sizeof(name), "raid1_%s", raid_bdev->bdev.name);
@@ -643,9 +725,60 @@ channel_grow_base_bdev(struct raid_bdev *raid_bdev, struct raid_bdev_io_channel 
 		memset(tmp + raid_ch_num_channels * sizeof(*raid1_ch->read_blocks_outstanding), 0,
 		       sizeof(*raid1_ch->read_blocks_outstanding));
 		raid1_ch->read_blocks_outstanding = tmp;
+
+		tmp = realloc(raid1_ch->delta_bitmaps,
+			      raid_bdev->num_base_bdevs * sizeof(*raid1_ch->delta_bitmaps));
+		if (!tmp) {
+			SPDK_ERRLOG("Unable to reallocate raid1 channel delta_bitmaps\n");
+			return false;
+		}
+		memset(tmp + raid_ch_num_channels * sizeof(*raid1_ch->delta_bitmaps), 0,
+		       sizeof(*raid1_ch->delta_bitmaps));
+		raid1_ch->delta_bitmaps = tmp;
 	}
 
 	return true;
+}
+
+static int
+channel_faulty_base_bdev(struct raid_base_bdev_info *base_info,
+			 struct raid_bdev_io_channel *raid_ch,
+			 enum base_bdev_state newState)
+{
+	uint8_t idx = base_info - base_info->raid_bdev->base_bdev_info;
+	struct spdk_bdev *bdev = &base_info->raid_bdev->bdev;
+	struct raid1_io_channel *r1_ch = raid_bdev_channel_get_module_ctx(raid_ch);
+	uint32_t region_block_number = raid_bdev_delta_bitmap_region_blocks_number(bdev);
+	enum base_bdev_state state = r1_ch->states[idx];
+	uint32_t i;
+
+	if (state == BASE_BDEV_STATE_NONE && newState == BASE_BDEV_STATE_FAULTY) {
+		/* Starting faulty state */
+		r1_ch->delta_bitmaps[idx] = spdk_bit_array_create(region_block_number);
+
+		if (!r1_ch->delta_bitmaps[idx]) {
+			return -ENOMEM;
+		}
+	} else if (state == BASE_BDEV_STATE_FAULTY && newState == BASE_BDEV_STATE_FAULTY_STOPPED) {
+		/* Stopping faulty state */
+		for (i = 0; i < region_block_number; i++) {
+			if (spdk_bit_array_get(r1_ch->delta_bitmaps[idx], i)) {
+				spdk_bit_array_set(base_info->delta_bitmap, i);
+			}
+		}
+	} else if ((state == BASE_BDEV_STATE_FAULTY || state == BASE_BDEV_STATE_FAULTY_STOPPED) &&
+		   newState == BASE_BDEV_STATE_NONE) {
+		/* Clearing faulty state */
+		if (r1_ch->delta_bitmaps[idx]) {
+			spdk_bit_array_free(&r1_ch->delta_bitmaps[idx]);
+		}
+	} else if (state == BASE_BDEV_STATE_FAULTY_STOPPED && newState == BASE_BDEV_STATE_FAULTY) {
+		/* This can happen if the creation of delta_bitmap failed in raid1_handle_faulty_base_bdev */
+		return -ENOMEM;
+	}
+
+	r1_ch->states[idx] = newState;
+	return 0;
 }
 
 static struct raid_bdev_module g_raid1_module = {
@@ -660,6 +793,7 @@ static struct raid_bdev_module g_raid1_module = {
 	.get_io_channel = raid1_get_io_channel,
 	.submit_process_request = raid1_submit_process_request,
 	.channel_grow_base_bdev = channel_grow_base_bdev,
+	.channel_faulty_base_bdev = channel_faulty_base_bdev,
 };
 RAID_MODULE_REGISTER(&g_raid1_module)
 

--- a/python/spdk/rpc/bdev.py
+++ b/python/spdk/rpc/bdev.py
@@ -417,7 +417,8 @@ def bdev_raid_get_bdevs(client, category):
     return client.call('bdev_raid_get_bdevs', params)
 
 
-def bdev_raid_create(client, name, raid_level, base_bdevs, strip_size=None, strip_size_kb=None, uuid=None, superblock=False):
+def bdev_raid_create(client, name, raid_level, base_bdevs, strip_size=None, strip_size_kb=None, uuid=None, superblock=False,
+                     delta_bitmap=False):
     """Create raid bdev. Either strip size arg will work but one is required.
 
     Args:
@@ -429,6 +430,7 @@ def bdev_raid_create(client, name, raid_level, base_bdevs, strip_size=None, stri
         uuid: UUID for this raid bdev (optional)
         superblock: information about raid bdev will be stored in superblock on each base bdev,
                     disabled by default due to backward compatibility
+        delta_bitmap: a delta bitmap for faulty base bdevs will be recorded
 
     Returns:
         None
@@ -443,6 +445,9 @@ def bdev_raid_create(client, name, raid_level, base_bdevs, strip_size=None, stri
 
     if uuid:
         params['uuid'] = uuid
+
+    if delta_bitmap:
+        params['delta_bitmap'] = delta_bitmap
 
     return client.call('bdev_raid_create', params)
 
@@ -501,6 +506,45 @@ def bdev_raid_grow_base_bdev(client, raid_name, base_name):
     params = {'raid_name': raid_name, 'base_name': base_name}
 
     return client.call('bdev_raid_grow_base_bdev', params)
+
+
+def bdev_raid_get_base_bdev_delta_bitmap(client, base_bdev_name):
+    """Get the delta bitmap of a faulty base bdev
+
+    Args:
+        base_bdev_name: base bdev name
+
+    Returns:
+        None
+    """
+    params = {'base_bdev_name': base_bdev_name}
+    return client.call('bdev_raid_get_base_bdev_delta_bitmap', params)
+
+
+def bdev_raid_stop_base_bdev_delta_bitmap(client, base_bdev_name):
+    """Stop the updating of the delta bitmap of a faulty base bdev
+
+    Args:
+        base_bdev_name: base bdev name
+
+    Returns:
+        None
+    """
+    params = {'base_bdev_name': base_bdev_name}
+    return client.call('bdev_raid_stop_base_bdev_delta_bitmap', params)
+
+
+def bdev_raid_clear_base_bdev_faulty_state(client, base_bdev_name):
+    """Clear the faulty state of a base bdev
+
+    Args:
+        base_bdev_name: base bdev name
+
+    Returns:
+        None
+    """
+    params = {'base_bdev_name': base_bdev_name}
+    return client.call('bdev_raid_clear_base_bdev_faulty_state', params)
 
 
 def bdev_aio_create(client, filename, name, block_size=None, readonly=False, fallocate=False):

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -2283,7 +2283,8 @@ Format: 'user:u1 secret:s1 muser:mu1 msecret:ms1,user:u2 secret:s2 muser:mu2 mse
                                   raid_level=args.raid_level,
                                   base_bdevs=base_bdevs,
                                   uuid=args.uuid,
-                                  superblock=args.superblock)
+                                  superblock=args.superblock,
+                                  delta_bitmap=args.delta_bitmap)
     p = subparsers.add_parser('bdev_raid_create', help='Create new raid bdev')
     p.add_argument('-n', '--name', help='raid bdev name', required=True)
     p.add_argument('-z', '--strip-size-kb', help='strip size in KB', type=int)
@@ -2292,6 +2293,7 @@ Format: 'user:u1 secret:s1 muser:mu1 msecret:ms1,user:u2 secret:s2 muser:mu2 mse
     p.add_argument('--uuid', help='UUID for this raid bdev')
     p.add_argument('-s', '--superblock', help='information about raid bdev will be stored in superblock on each base bdev, '
                                               'disabled by default due to backward compatibility', action='store_true')
+    p.add_argument('-d', '--delta-bitmap', help='a delta bitmap for faulty base bdevs will be recorded', action='store_true')
     p.set_defaults(func=bdev_raid_create)
 
     def bdev_raid_delete(args):
@@ -2326,6 +2328,28 @@ Format: 'user:u1 secret:s1 muser:mu1 msecret:ms1,user:u2 secret:s2 muser:mu2 mse
     p.add_argument('raid_name', help='raid bdev name')
     p.add_argument('base_name', help='base bdev name')
     p.set_defaults(func=bdev_raid_grow_base_bdev)
+
+    def bdev_raid_get_base_bdev_delta_bitmap(args):
+        print_json(rpc.bdev.bdev_raid_get_base_bdev_delta_bitmap(args.client,
+                                                                 base_bdev_name=args.base_bdev_name))
+    p = subparsers.add_parser('bdev_raid_get_base_bdev_delta_bitmap', help='Get the delta bitmap of a faulty base bdev')
+    p.add_argument('base_bdev_name', help='base bdev name')
+    p.set_defaults(func=bdev_raid_get_base_bdev_delta_bitmap)
+
+    def bdev_raid_stop_base_bdev_delta_bitmap(args):
+        rpc.bdev.bdev_raid_stop_base_bdev_delta_bitmap(args.client,
+                                                       base_bdev_name=args.base_bdev_name)
+    p = subparsers.add_parser('bdev_raid_stop_base_bdev_delta_bitmap', help="""Stop the updating of the delta bitmap
+                              of a faulty base bdev""")
+    p.add_argument('base_bdev_name', help='base bdev name')
+    p.set_defaults(func=bdev_raid_stop_base_bdev_delta_bitmap)
+
+    def bdev_raid_clear_base_bdev_faulty_state(args):
+        rpc.bdev.bdev_raid_clear_base_bdev_faulty_state(args.client,
+                                                        base_bdev_name=args.base_bdev_name)
+    p = subparsers.add_parser('bdev_raid_clear_base_bdev_faulty_state', help='Clear the faulty state of a base bdev')
+    p.add_argument('base_bdev_name', help='base bdev name')
+    p.set_defaults(func=bdev_raid_clear_base_bdev_faulty_state)
 
     # split
     def bdev_split_create(args):

--- a/test/unit/lib/bdev/raid/raid1.c/raid1_ut.c
+++ b/test/unit/lib/bdev/raid/raid1.c/raid1_ut.c
@@ -69,6 +69,11 @@ raid_bdev_fail_base_bdev(struct raid_base_bdev_info *base_info)
 	base_info->is_failed = true;
 }
 
+struct raid_base_bdev_info *raid_bdev_find_base_info_by_bdev(struct spdk_bdev *base_bdev)
+{
+	return NULL;
+}
+
 static int
 test_setup(void)
 {


### PR DESCRIPTION
A delta bitmap for fast rebuild is created and updated for a defined amout of time when the bdev of a base bdev is deleted or when it gets write I/O error.

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #5573

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
