### PR TITLE
feat(lvol): lvol flush implementation

### DIFF
--- a/include/spdk_internal/lvolstore.h
+++ b/include/spdk_internal/lvolstore.h
@@ -112,7 +112,7 @@ struct spdk_lvol_store {
 	struct spdk_thread		*thread;
 };
 
-typedef TAILQ_HEAD(, freezing_lvol) freeze_lvol_tailq_t;
+typedef TAILQ_HEAD(, freeze_range) lvol_freeze_range_tailq_t;
 
 struct spdk_lvol {
 	struct spdk_lvol_store		*lvol_store;
@@ -132,8 +132,16 @@ struct spdk_lvol {
 	TAILQ_ENTRY(spdk_lvol)		degraded_link;
 
 	struct spdk_spinlock		spinlock;
-	freeze_lvol_tailq_t		ongoing_quiescences;	/* Protected by spinlock */
-	freeze_lvol_tailq_t		pending_quiescences;	/* Protected by spinlock */
+	/*
+	 * Currently freezed ranges for this lvol. Used to populate new channels.
+	 * Protected by spinlock.
+	 */
+	lvol_freeze_range_tailq_t	freezed_ranges;
+	/* Pending freezed ranges for this lvol. These ranges are not currently
+	 * freezed due to overlapping with another freezed range.
+	 * Protected by spinlock.
+	 */
+	lvol_freeze_range_tailq_t	pending_freezed_ranges;
 };
 
 struct spdk_fragmap {

--- a/lib/lvol/lvol.c
+++ b/lib/lvol/lvol.c
@@ -120,8 +120,8 @@ lvol_alloc(struct spdk_lvol_store *lvs, const char *name, bool thin_provision,
 	TAILQ_INSERT_TAIL(&lvs->pending_lvols, lvol, link);
 
 	spdk_spin_init(&lvol->spinlock);
-	TAILQ_INIT(&lvol->ongoing_quiescences);
-	TAILQ_INIT(&lvol->pending_quiescences);
+	TAILQ_INIT(&lvol->freezed_ranges);
+	TAILQ_INIT(&lvol->pending_freezed_ranges);
 
 	return lvol;
 }
@@ -332,8 +332,8 @@ load_next_lvol(void *cb_arg, struct spdk_blob *blob, int lvolerrno)
 	}
 
 	spdk_spin_init(&lvol->spinlock);
-	TAILQ_INIT(&lvol->ongoing_quiescences);
-	TAILQ_INIT(&lvol->pending_quiescences);
+	TAILQ_INIT(&lvol->freezed_ranges);
+	TAILQ_INIT(&lvol->pending_freezed_ranges);
 
 	TAILQ_INSERT_TAIL(&lvs->lvols, lvol, link);
 

--- a/module/bdev/lvol/vbdev_lvol.c
+++ b/module/bdev/lvol/vbdev_lvol.c
@@ -15,6 +15,11 @@
 
 #include "vbdev_lvol.h"
 
+struct spdk_lvol_channel {
+	/* The channel for the underlying blobstore device */
+	struct spdk_io_channel	*bs_channel;
+};
+
 struct vbdev_lvol_io {
 	struct spdk_blob_ext_io_opts ext_io_opts;
 };
@@ -117,6 +122,49 @@ _vbdev_lvol_change_bdev_alias(struct spdk_lvol *lvol, const char *new_lvol_name)
 	}
 
 	return 0;
+}
+
+static int
+vbdev_lvol_channel_create(void *io_device, void *ctx_buf)
+{
+	struct spdk_lvol		*lvol = io_device;
+	struct spdk_lvol_channel	*channel = ctx_buf;
+
+	channel->bs_channel = spdk_lvol_get_io_channel(lvol);
+
+	return 0;
+}
+
+static void
+vbdev_lvol_channel_destroy(void *io_device, void *ctx_buf)
+{
+	struct spdk_lvol_channel *channel = ctx_buf;
+
+	spdk_put_io_channel(channel->bs_channel);
+}
+
+static int
+vbdev_lvol_register(struct spdk_lvol *lvol, struct spdk_bdev *lvol_bdev)
+{
+	int rc;
+
+	/* We must register lvol as io_device before to register lvol bdev */
+	spdk_io_device_register(lvol, vbdev_lvol_channel_create, vbdev_lvol_channel_destroy,
+				sizeof(struct spdk_lvol_channel), "lvol");
+
+	rc = spdk_bdev_register(lvol_bdev);
+	if (rc) {
+		spdk_io_device_unregister(lvol, NULL);
+	}
+
+	return rc;
+}
+
+static void
+vbdev_lvol_unregister(struct spdk_lvol *lvol, spdk_bdev_unregister_cb cb_fn, void *cb_arg)
+{
+	spdk_io_device_unregister(lvol, NULL);
+	spdk_bdev_unregister(lvol->bdev, cb_fn, cb_arg);
 }
 
 static struct lvol_store_bdev *
@@ -555,7 +603,7 @@ struct vbdev_lvol_destroy_ctx {
 };
 
 static void
-_vbdev_lvol_unregister_unload_lvs(void *cb_arg, int lvserrno)
+_vbdev_lvol_destruct_unload_lvs(void *cb_arg, int lvserrno)
 {
 	struct lvol_bdev *lvol_bdev = cb_arg;
 	struct lvol_store_bdev *lvs_bdev = lvol_bdev->lvs_bdev;
@@ -572,13 +620,15 @@ _vbdev_lvol_unregister_unload_lvs(void *cb_arg, int lvserrno)
 }
 
 static void
-_vbdev_lvol_unregister_cb(void *ctx, int lvolerrno)
+_vbdev_lvol_destruct_cb(void *ctx, int lvolerrno)
 {
 	struct lvol_bdev *lvol_bdev = ctx;
 	struct lvol_store_bdev *lvs_bdev = lvol_bdev->lvs_bdev;
 
+	spdk_io_device_unregister(lvol_bdev->lvol, NULL);
+
 	if (g_shutdown_started && _vbdev_lvs_are_lvols_closed(lvs_bdev->lvs)) {
-		spdk_lvs_unload(lvs_bdev->lvs, _vbdev_lvol_unregister_unload_lvs, lvol_bdev);
+		spdk_lvs_unload(lvs_bdev->lvs, _vbdev_lvol_destruct_unload_lvs, lvol_bdev);
 		return;
 	}
 
@@ -587,7 +637,7 @@ _vbdev_lvol_unregister_cb(void *ctx, int lvolerrno)
 }
 
 static int
-vbdev_lvol_unregister(void *ctx)
+vbdev_lvol_destruct(void *ctx)
 {
 	struct spdk_lvol *lvol = ctx;
 	struct lvol_bdev *lvol_bdev;
@@ -596,7 +646,7 @@ vbdev_lvol_unregister(void *ctx)
 	lvol_bdev = SPDK_CONTAINEROF(lvol->bdev, struct lvol_bdev, bdev);
 
 	spdk_bdev_alias_del_all(lvol->bdev);
-	spdk_lvol_close(lvol, _vbdev_lvol_unregister_cb, lvol_bdev);
+	spdk_lvol_close(lvol, _vbdev_lvol_destruct_cb, lvol_bdev);
 
 	/* return 1 to indicate we have an operation that must finish asynchronously before the
 	 *  lvol is closed
@@ -810,9 +860,7 @@ vbdev_lvol_write_config_json(struct spdk_bdev *bdev, struct spdk_json_write_ctx 
 static struct spdk_io_channel *
 vbdev_lvol_get_io_channel(void *ctx)
 {
-	struct spdk_lvol *lvol = ctx;
-
-	return spdk_lvol_get_io_channel(lvol);
+	return spdk_get_io_channel(ctx);
 }
 
 static bool
@@ -942,18 +990,21 @@ lvol_reset(struct spdk_bdev_io *bdev_io)
 static void
 lvol_get_buf_cb(struct spdk_io_channel *ch, struct spdk_bdev_io *bdev_io, bool success)
 {
+	struct spdk_lvol_channel *lvol_ch = (struct spdk_lvol_channel *)spdk_io_channel_get_ctx(ch);
+
 	if (!success) {
 		spdk_bdev_io_complete(bdev_io, SPDK_BDEV_IO_STATUS_FAILED);
 		return;
 	}
 
-	lvol_read(ch, bdev_io);
+	lvol_read(lvol_ch->bs_channel, bdev_io);
 }
 
 static void
 vbdev_lvol_submit_request(struct spdk_io_channel *ch, struct spdk_bdev_io *bdev_io)
 {
 	struct spdk_lvol *lvol = bdev_io->bdev->ctxt;
+	struct spdk_lvol_channel *lvol_ch = (struct spdk_lvol_channel *)spdk_io_channel_get_ctx(ch);
 
 	switch (bdev_io->type) {
 	case SPDK_BDEV_IO_TYPE_READ:
@@ -961,16 +1012,16 @@ vbdev_lvol_submit_request(struct spdk_io_channel *ch, struct spdk_bdev_io *bdev_
 				     bdev_io->u.bdev.num_blocks * bdev_io->bdev->blocklen);
 		break;
 	case SPDK_BDEV_IO_TYPE_WRITE:
-		lvol_write(lvol, ch, bdev_io);
+		lvol_write(lvol, lvol_ch->bs_channel, bdev_io);
 		break;
 	case SPDK_BDEV_IO_TYPE_RESET:
 		lvol_reset(bdev_io);
 		break;
 	case SPDK_BDEV_IO_TYPE_UNMAP:
-		lvol_unmap(lvol, ch, bdev_io);
+		lvol_unmap(lvol, lvol_ch->bs_channel, bdev_io);
 		break;
 	case SPDK_BDEV_IO_TYPE_WRITE_ZEROES:
-		lvol_write_zeroes(lvol, ch, bdev_io);
+		lvol_write_zeroes(lvol, lvol_ch->bs_channel, bdev_io);
 		break;
 	case SPDK_BDEV_IO_TYPE_SEEK_DATA:
 		lvol_seek_data(lvol, bdev_io);
@@ -1060,7 +1111,7 @@ vbdev_lvol_get_memory_domains(void *ctx, struct spdk_memory_domain **domains, in
 }
 
 static struct spdk_bdev_fn_table vbdev_lvol_fn_table = {
-	.destruct		= vbdev_lvol_unregister,
+	.destruct		= vbdev_lvol_destruct,
 	.io_type_supported	= vbdev_lvol_io_type_supported,
 	.submit_request		= vbdev_lvol_submit_request,
 	.get_io_channel		= vbdev_lvol_get_io_channel,
@@ -1160,7 +1211,7 @@ _create_lvol_disk(struct spdk_lvol *lvol, bool destroy)
 	 * bdev that may be used by multiple lvols. */
 	bdev->reset_io_drain_timeout = SPDK_BDEV_RESET_IO_DRAIN_RECOMMENDED_VALUE;
 
-	rc = spdk_bdev_register(bdev);
+	rc = vbdev_lvol_register(lvol, bdev);
 	if (rc) {
 		free(lvol_bdev);
 		return rc;
@@ -1170,16 +1221,16 @@ _create_lvol_disk(struct spdk_lvol *lvol, bool destroy)
 	alias = spdk_sprintf_alloc("%s/%s", lvs_bdev->lvs->name, lvol->name);
 	if (alias == NULL) {
 		SPDK_ERRLOG("Cannot alloc memory for alias\n");
-		spdk_bdev_unregister(lvol->bdev, (destroy ? _create_lvol_disk_destroy_cb :
-						  _create_lvol_disk_unload_cb), lvol);
+		vbdev_lvol_unregister(lvol, (destroy ? _create_lvol_disk_destroy_cb :
+					     _create_lvol_disk_unload_cb), lvol);
 		return -ENOMEM;
 	}
 
 	rc = spdk_bdev_alias_add(bdev, alias);
 	if (rc != 0) {
 		SPDK_ERRLOG("Cannot add alias to lvol bdev\n");
-		spdk_bdev_unregister(lvol->bdev, (destroy ? _create_lvol_disk_destroy_cb :
-						  _create_lvol_disk_unload_cb), lvol);
+		vbdev_lvol_unregister(lvol, (destroy ? _create_lvol_disk_destroy_cb :
+					     _create_lvol_disk_unload_cb), lvol);
 	}
 	free(alias);
 

--- a/module/bdev/lvol/vbdev_lvol.c
+++ b/module/bdev/lvol/vbdev_lvol.c
@@ -918,7 +918,7 @@ lvol_seek_data(struct spdk_lvol *lvol, struct spdk_bdev_io *bdev_io)
 	bdev_io->u.bdev.seek.offset = spdk_blob_get_next_allocated_io_unit(lvol->blob,
 				      bdev_io->u.bdev.offset_blocks);
 
-	spdk_bdev_io_complete(bdev_io, SPDK_BDEV_IO_STATUS_SUCCESS);
+	lvol_op_comp(bdev_io, 0);
 }
 
 static void
@@ -927,7 +927,7 @@ lvol_seek_hole(struct spdk_lvol *lvol, struct spdk_bdev_io *bdev_io)
 	bdev_io->u.bdev.seek.offset = spdk_blob_get_next_unallocated_io_unit(lvol->blob,
 				      bdev_io->u.bdev.offset_blocks);
 
-	spdk_bdev_io_complete(bdev_io, SPDK_BDEV_IO_STATUS_SUCCESS);
+	lvol_op_comp(bdev_io, 0);
 }
 
 static void
@@ -982,7 +982,7 @@ lvol_write(struct spdk_lvol *lvol, struct spdk_io_channel *ch, struct spdk_bdev_
 static int
 lvol_reset(struct spdk_bdev_io *bdev_io)
 {
-	spdk_bdev_io_complete(bdev_io, SPDK_BDEV_IO_STATUS_FAILED);
+	lvol_op_comp(bdev_io, -EPERM);
 
 	return 0;
 }

--- a/test/unit/lib/bdev/vbdev_lvol.c/vbdev_lvol_ut.c
+++ b/test/unit/lib/bdev/vbdev_lvol.c/vbdev_lvol_ut.c
@@ -26,6 +26,7 @@ struct spdk_lvol *g_lvol = NULL;
 struct lvol_store_bdev *g_lvs_bdev = NULL;
 struct spdk_bdev_io *g_io = NULL;
 struct spdk_io_channel *g_ch = NULL;
+struct spdk_io_channel *g_bs_ch = NULL;
 
 #define DEFAULT_BDEV_NAME "bdev"
 #define DEFAULT_BDEV_UUID "a27fd8fe-d4b9-431e-a044-271016228ce4"
@@ -57,6 +58,7 @@ DEFINE_STUB(spdk_lvs_esnap_missing_add, int,
 	     uint32_t id_len), -ENOTSUP);
 DEFINE_STUB(spdk_blob_get_esnap_bs_dev, struct spdk_bs_dev *, (const struct spdk_blob *blob), NULL);
 DEFINE_STUB(spdk_lvol_is_degraded, bool, (const struct spdk_lvol *lvol), false);
+DEFINE_STUB_V(spdk_bs_free_io_channel, (struct spdk_io_channel *channel));
 DEFINE_STUB(spdk_blob_get_num_allocated_clusters, uint64_t, (struct spdk_blob *blob), 0);
 
 struct spdk_blob {
@@ -670,7 +672,8 @@ spdk_bdev_io_complete(struct spdk_bdev_io *bdev_io, enum spdk_bdev_io_status sta
 struct spdk_io_channel *spdk_lvol_get_io_channel(struct spdk_lvol *lvol)
 {
 	CU_ASSERT(lvol == g_lvol);
-	return g_ch;
+	g_bs_ch = spdk_get_io_channel(g_lvol);
+	return g_bs_ch;
 }
 
 void
@@ -977,6 +980,20 @@ static void
 vbdev_lvol_shallow_copy_complete(void *cb_arg, int lvolerrno)
 {
 	g_lvolerrno = lvolerrno;
+}
+
+static struct spdk_io_channel *
+_vbdev_lvol_get_io_channel(void *ctx)
+{
+	g_ch = spdk_get_io_channel(ctx);
+	return g_ch;
+}
+
+static void
+_vbdev_lvol_put_io_channel(struct spdk_io_channel *ch)
+{
+	spdk_put_io_channel(g_bs_ch);
+	spdk_put_io_channel(ch);
 }
 
 static void
@@ -1681,15 +1698,48 @@ ut_lvs_init(void)
 static void
 ut_vbdev_lvol_get_io_channel(void)
 {
+	struct spdk_lvol_store *lvs;
 	struct spdk_io_channel *ch;
+	struct spdk_lvol_channel *lvol_ch;
+	int sz = 10;
+	int rc;
 
-	g_lvol = calloc(1, sizeof(struct spdk_lvol));
-	SPDK_CU_ASSERT_FATAL(g_lvol != NULL);
+	ut_init_bdev(DEFAULT_BDEV_NAME, DEFAULT_BDEV_UUID);
 
-	ch = vbdev_lvol_get_io_channel(g_lvol);
-	CU_ASSERT(ch == g_ch);
+	/* Create lvol store */
+	rc = vbdev_lvs_create("bdev", "lvs", 0, LVS_CLEAR_WITH_UNMAP, 0,
+			      lvol_store_op_with_handle_complete, NULL);
+	CU_ASSERT(rc == 0);
+	CU_ASSERT(g_lvserrno == 0);
+	SPDK_CU_ASSERT_FATAL(g_lvol_store != NULL);
+	CU_ASSERT(g_lvol_store->bs_dev != NULL);
+	lvs = g_lvol_store;
 
-	free(g_lvol);
+	/* Create lvol */
+	g_lvolerrno = -1;
+	rc = vbdev_lvol_create(lvs, "lvol", sz, false, LVOL_CLEAR_WITH_DEFAULT, vbdev_lvol_create_complete,
+			       NULL);
+	SPDK_CU_ASSERT_FATAL(rc == 0);
+	CU_ASSERT(g_lvol != NULL);
+	CU_ASSERT(g_lvolerrno == 0);
+
+	/* Get io channel */
+	ch = _vbdev_lvol_get_io_channel(g_lvol);
+	CU_ASSERT(ch != NULL);
+	lvol_ch = (struct spdk_lvol_channel *)spdk_io_channel_get_ctx(ch);
+	CU_ASSERT(lvol_ch->bs_channel == g_bs_ch);
+
+	/* Release io channel */
+	_vbdev_lvol_put_io_channel(ch);
+
+	/* Destroy lvol */
+	vbdev_lvol_destroy(g_lvol, lvol_store_op_complete, NULL);
+	CU_ASSERT(g_lvol == NULL);
+
+	/* Destroy lvol store */
+	vbdev_lvs_destruct(lvs, lvol_store_op_complete, NULL);
+	CU_ASSERT(g_lvserrno == 0);
+	CU_ASSERT(g_lvol_store == NULL);
 }
 
 static void


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/8730

#### What this PR does / why we need it:

Original flush implementation had a memory leak when used in conjunction with reparent functionalities. Now the leak is solved and the flush implementation has been updated for the new longhorn-v24.09 branch (inside SPDK some stuff changed in last months).

#### Special notes for your reviewer:

#### Additional documentation or context
