### PR TITLE
feat(lvol): new RPC bdev_lvol_detach_parent

### DIFF
--- a/doc/jsonrpc.md
+++ b/doc/jsonrpc.md
@@ -490,6 +490,7 @@ Example response:
     "bdev_lvol_delete",
     "bdev_lvol_resize",
     "bdev_lvol_set_read_only",
+    "bdev_lvol_detach_parent",
     "bdev_lvol_decouple_parent",
     "bdev_lvol_inflate",
     "bdev_lvol_rename",
@@ -10934,6 +10935,43 @@ Example request:
 {
   "jsonrpc": "2.0",
   "method": "bdev_lvol_decouple_parent",
+  "id": 1.
+  "params": {
+    "name": "8d87fccc-c278-49f0-9d4c-6237951aca09"
+  }
+}
+~~~
+
+Example response:
+
+~~~json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": true
+}
+~~~
+
+### bdev_lvol_detach_parent {#rpc_bdev_lvol_detach_parent}
+
+Detach the parent snapshot of a logical volume. No new clusters are allocated to the child blob,
+no data are copied from the parent to the child, so lvol's data are not modified. The parent must
+be a standard snapshot, not an external snapshot. All dependencies on the parent are removed.
+
+#### Parameters
+
+Name                    | Optional | Type        | Description
+----------------------- | -------- | ----------- | -----------
+name                    | Required | string      | UUID or alias of the logical volume to detach the parent of it
+
+#### Example
+
+Example request:
+
+~~~json
+{
+  "jsonrpc": "2.0",
+  "method": "bdev_lvol_detach_parent",
   "id": 1.
   "params": {
     "name": "8d87fccc-c278-49f0-9d4c-6237951aca09"

--- a/doc/lvol.md
+++ b/doc/lvol.md
@@ -198,6 +198,10 @@ bdev_lvol_decouple_parent [-h] name
     Decouple parent of a logical volume
     optional arguments:
     -h, --help  show help
+bdev_lvol_detach_parent [-h] name
+    Detach parent of a logical volume
+    optional arguments:
+    -h, --help  show help
 bdev_lvol_start_shallow_copy [-h] src_lvol_name dst_bdev_name
     Make a shallow copy of lvol over a given bdev
     This RPC starts the operation and returns an identifier that can be used to query the status

--- a/include/spdk/blob.h
+++ b/include/spdk/blob.h
@@ -800,6 +800,23 @@ void spdk_bs_blob_decouple_parent(struct spdk_blob_store *bs, struct spdk_io_cha
 				  spdk_blob_id blobid, spdk_blob_op_complete cb_fn, void *cb_arg);
 
 /**
+ * Detach from parent blob without modifying data.
+ *
+ * This call remove the dependencies of a blob from its parent snapshot without allocate any new
+ * cluster in the child blob, as for example it happens in decouple from parent. In this way
+ * blob's data are not modified.
+ *
+ * If blob have no parent, or if the parent is an external snapshot, -EINVAL error is reported.
+ *
+ * \param bs blobstore.
+ * \param blobid The id of the blob.
+ * \param cb_fn Called when the operation is complete.
+ * \param cb_arg Argument passed to function cb_fn.
+ */
+void spdk_bs_blob_detach_parent(struct spdk_blob_store *bs, spdk_blob_id blobid,
+				spdk_blob_op_complete cb_fn, void *cb_arg);
+
+/**
  * Perform a shallow copy of a blob to a blobstore device.
  *
  * This makes a shallow copy from a blob to a blobstore device.

--- a/include/spdk/lvol.h
+++ b/include/spdk/lvol.h
@@ -434,6 +434,15 @@ void spdk_lvol_inflate(struct spdk_lvol *lvol, spdk_lvol_op_complete cb_fn, void
 void spdk_lvol_decouple_parent(struct spdk_lvol *lvol, spdk_lvol_op_complete cb_fn, void *cb_arg);
 
 /**
+ * Detach parent of lvol
+ *
+ * \param lvol Handle to lvol
+ * \param cb_fn Completion callback
+ * \param cb_arg Completion callback custom arguments
+ */
+void spdk_lvol_detach_parent(struct spdk_lvol *lvol, spdk_lvol_op_complete cb_fn, void *cb_arg);
+
+/**
  * Determine if an lvol is degraded. A degraded lvol cannot perform IO.
  *
  * \param lvol Handle to lvol

--- a/lib/blob/spdk_blob.map
+++ b/lib/blob/spdk_blob.map
@@ -40,6 +40,7 @@
 	spdk_bs_delete_blob;
 	spdk_bs_inflate_blob;
 	spdk_bs_blob_decouple_parent;
+	spdk_bs_blob_detach_parent;
 	spdk_bs_blob_shallow_copy;
 	spdk_bs_blob_set_parent;
 	spdk_bs_blob_set_external_parent;

--- a/lib/lvol/spdk_lvol.map
+++ b/lib/lvol/spdk_lvol.map
@@ -24,6 +24,7 @@
 	spdk_lvol_open;
 	spdk_lvol_inflate;
 	spdk_lvol_decouple_parent;
+	spdk_lvol_detach_parent;
 	spdk_lvol_create_esnap_clone;
 	spdk_lvol_iter_immediate_clones;
 	spdk_lvol_get_by_uuid;

--- a/python/spdk/rpc/lvol.py
+++ b/python/spdk/rpc/lvol.py
@@ -257,6 +257,18 @@ def bdev_lvol_decouple_parent(client, name):
     return client.call('bdev_lvol_decouple_parent', params)
 
 
+def bdev_lvol_detach_parent(client, name):
+    """Detach parent of a logical volume.
+
+    Args:
+        name: name of logical volume to detach parent
+    """
+    params = {
+        'name': name,
+    }
+    return client.call('bdev_lvol_detach_parent', params)
+
+
 def bdev_lvol_start_shallow_copy(client, src_lvol_name, dst_bdev_name):
     """Start a shallow copy of an lvol over a given bdev. The status of the operation
     can be obtained with bdev_lvol_check_shallow_copy

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -2191,6 +2191,14 @@ Format: 'user:u1 secret:s1 muser:mu1 msecret:ms1,user:u2 secret:s2 muser:mu2 mse
     p.add_argument('name', help='lvol bdev name')
     p.set_defaults(func=bdev_lvol_decouple_parent)
 
+    def bdev_lvol_detach_parent(args):
+        rpc.lvol.bdev_lvol_detach_parent(args.client,
+                                         name=args.name)
+
+    p = subparsers.add_parser('bdev_lvol_detach_parent', help='Detach parent of lvol')
+    p.add_argument('name', help='lvol bdev name')
+    p.set_defaults(func=bdev_lvol_detach_parent)
+
     def bdev_lvol_resize(args):
         rpc.lvol.bdev_lvol_resize(args.client,
                                   name=args.name,

--- a/test/lvol/snapshot_clone.sh
+++ b/test/lvol/snapshot_clone.sh
@@ -373,6 +373,103 @@ function test_clone_decouple_parent() {
 	check_leftover_devices
 }
 
+# Create chain of snapshot<-snapshot2<-lvol_test lvol bdevs.
+# Detach lvol_test twice and delete the remaining snapshot lvol.
+# Each time check consistency of snapshot-clone relations and written data.
+function test_clone_detach_parent() {
+	malloc_name=$(rpc_cmd bdev_malloc_create $MALLOC_SIZE_MB $MALLOC_BS)
+	lvs_uuid=$(rpc_cmd bdev_lvol_create_lvstore "$malloc_name" lvs_test)
+
+	# Calculate size and create lvol bdev
+	lvol_size_mb=$((5 * LVS_DEFAULT_CLUSTER_SIZE_MB))
+	lvol_uuid=$(rpc_cmd bdev_lvol_create -u "$lvs_uuid" lvol_test "$lvol_size_mb" -t)
+	lvol=$(rpc_cmd bdev_get_bdevs -b "$lvol_uuid")
+
+	# Detach_parent should fail on lvol bdev without a parent
+	rpc_cmd bdev_lvol_detach_parent lvs_test/lvol_test && false
+
+	# Fill first four out of 5 clusters of clone with data of known pattern
+	nbd_start_disks "$DEFAULT_RPC_ADDR" "$lvol_uuid" /dev/nbd0
+	begin_fill=0
+	end_fill=$((lvol_size_mb * 4 * 1024 * 1024 / 5))
+	run_fio_test /dev/nbd0 $begin_fill $end_fill "write" "0xdd"
+
+	# Create snapshot (snapshot<-lvol_bdev)
+	snapshot_uuid=$(rpc_cmd bdev_lvol_snapshot lvs_test/lvol_test lvol_snapshot)
+
+	# Fill second and fourth cluster of clone with data of known pattern
+	start_fill=$((lvol_size_mb * 1024 * 1024 / 5))
+	fill_range=$start_fill
+	run_fio_test /dev/nbd0 $start_fill $fill_range "write" "0xcc"
+	start_fill=$((lvol_size_mb * 3 * 1024 * 1024 / 5))
+	run_fio_test /dev/nbd0 $start_fill $fill_range "write" "0xcc"
+
+	# Create snapshot (snapshot<-snapshot2<-lvol_bdev)
+	snapshot_uuid2=$(rpc_cmd bdev_lvol_snapshot lvs_test/lvol_test lvol_snapshot2)
+
+	# Fill second cluster of clone with data of known pattern
+	start_fill=$fill_range
+	run_fio_test /dev/nbd0 $start_fill $fill_range "write" "0xee"
+
+	# Check data consistency
+	pattern=("0xdd" "0xee" "0xdd" "0xcc" "0x00")
+	for i in "${!pattern[@]}"; do
+		start_fill=$((lvol_size_mb * i * 1024 * 1024 / 5))
+		run_fio_test /dev/nbd0 $start_fill $fill_range "read" "${pattern[i]}"
+	done
+
+	# Detach_parent of lvol bdev resulting in two relation chains:
+	#  - snapshot<-lvol_bdev
+	#  - snapshot<-snapshot2
+	rpc_cmd bdev_lvol_detach_parent lvs_test/lvol_test
+	lvol=$(rpc_cmd bdev_get_bdevs -b "$lvol_uuid")
+	snapshot=$(rpc_cmd bdev_get_bdevs -b "$snapshot_uuid")
+	snapshot2=$(rpc_cmd bdev_get_bdevs -b "$snapshot_uuid2")
+	[ "$(jq '.[].driver_specific.lvol.thin_provision' <<< "$lvol")" = "true" ]
+	[ "$(jq '.[].driver_specific.lvol.clone' <<< "$lvol")" = "true" ]
+	[ "$(jq '.[].driver_specific.lvol.snapshot' <<< "$lvol")" = "false" ]
+	[ "$(jq '.[].driver_specific.lvol.clone' <<< "$snapshot")" = "false" ]
+	[ "$(jq '.[].driver_specific.lvol.clone' <<< "$snapshot2")" = "true" ]
+	[ "$(jq '.[].driver_specific.lvol.snapshot' <<< "$snapshot2")" = "true" ]
+
+	# Delete second snapshot
+	rpc_cmd bdev_lvol_delete "$snapshot_uuid2"
+
+	# Check data consistency
+	pattern=("0xdd" "0xee" "0xdd" "0xdd" "0x00")
+	for i in "${!pattern[@]}"; do
+		start_fill=$((lvol_size_mb * i * 1024 * 1024 / 5))
+		run_fio_test /dev/nbd0 $start_fill $fill_range "read" "${pattern[i]}"
+	done
+
+	# Detach_parent of lvol bdev again resulting in two relation chains:
+	#  - lvol_bdev
+	#  - snapshot<-snapshot2
+	rpc_cmd bdev_lvol_detach_parent lvs_test/lvol_test
+	lvol=$(rpc_cmd bdev_get_bdevs -b "$lvol_uuid")
+	snapshot=$(rpc_cmd bdev_get_bdevs -b "$snapshot_uuid")
+	[ "$(jq '.[].driver_specific.lvol.thin_provision' <<< "$lvol")" = "true" ]
+	[ "$(jq '.[].driver_specific.lvol.clone' <<< "$lvol")" = "false" ]
+	[ "$(jq '.[].driver_specific.lvol.snapshot' <<< "$lvol")" = "false" ]
+	[ "$(jq '.[].driver_specific.lvol.clone' <<< "$snapshot")" = "false" ]
+
+	# Delete first snapshot
+	rpc_cmd bdev_lvol_delete "$snapshot_uuid"
+
+	# Check data consistency
+	pattern=("0x00" "0xee" "0x00" "0x00" "0x00")
+	for i in "${!pattern[@]}"; do
+		start_fill=$((lvol_size_mb * i * 1024 * 1024 / 5))
+		run_fio_test /dev/nbd0 $start_fill $fill_range "read" "${pattern[i]}"
+	done
+
+	# Clean up
+	rpc_cmd bdev_lvol_delete "$lvol_uuid"
+	rpc_cmd bdev_lvol_delete_lvstore -u "$lvs_uuid"
+	rpc_cmd bdev_malloc_delete "$malloc_name"
+	check_leftover_devices
+}
+
 # Set lvol bdev as read only and perform clone on it.
 function test_lvol_bdev_readonly() {
 	malloc_name=$(rpc_cmd bdev_malloc_create $MALLOC_SIZE_MB $MALLOC_BS)
@@ -1000,6 +1097,7 @@ run_test "test_create_snapshot_of_snapshot" test_create_snapshot_of_snapshot
 run_test "test_clone_snapshot_relations" test_clone_snapshot_relations
 run_test "test_clone_inflate" test_clone_inflate
 run_test "test_clone_decouple_parent" test_clone_decouple_parent
+run_test "test_clone_detach_parent" test_clone_detach_parent
 run_test "test_lvol_bdev_readonly" test_lvol_bdev_readonly
 run_test "test_delete_snapshot_with_clone" test_delete_snapshot_with_clone
 run_test "test_delete_snapshot_with_snapshot" test_delete_snapshot_with_snapshot


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/9922

#### What this PR does / why we need it:
We need a RPC to remove the dependency of a logical volume from its snapshot parent without modifying lvol's data, so any new cluster must be allocated to the lvol and no data must be copied from parent to child.

#### Special notes for your reviewer:

#### Additional documentation or context
