### PR TITLE
blob: snapshot checksum log improvement

### DIFF
--- a/lib/blob/blobstore.c
+++ b/lib/blob/blobstore.c
@@ -8045,8 +8045,8 @@ bs_snapshot_checksum_blob_open_cpl(void *cb_arg, struct spdk_blob *_blob, int bs
 	ctx->blob = _blob;
 
 	if (_blob->locked_operation_in_progress) {
-		SPDK_DEBUGLOG(blob, "blob 0x%" PRIx64 " snapshot checksum - another operation in progress\n",
-			      _blob->id);
+		SPDK_ERRLOG("blob 0x%" PRIx64 " snapshot checksum - another operation in progress\n",
+			    _blob->id);
 		ctx->bserrno = -EBUSY;
 		spdk_blob_close(_blob, bs_snapshot_checksum_cleanup_finish, ctx);
 		return;


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue https://github.com/longhorn/longhorn/issues/10112 and https://github.com/longhorn/longhorn/issues/10140

#### What this PR does / why we need it:
When another operation over the same blob is in progress, an error log is created instead of a debug log.

#### Special notes for your reviewer:

#### Additional documentation or context
