### PR TITLE
fix(build): escape #

### DIFF
--- a/mk/spdk.common.mk
+++ b/mk/spdk.common.mk
@@ -581,7 +581,7 @@ $(shell [ "$(call cc_version)" = "$(1)" ] && echo 1 || echo 0)
 endef
 
 version_major := $(shell IFS='-.' read -r v _ _ _ < $(SPDK_ROOT_DIR)/VERSION; echo $$v)
-version_minor := $(shell IFS='-.' read -r _ v _ _ < $(SPDK_ROOT_DIR)/VERSION; echo $${v#0})
+version_minor := $(shell IFS='-.' read -r _ v _ _ < $(SPDK_ROOT_DIR)/VERSION; echo $${v\#0})
 version_patch := $(shell IFS='-.' read -r _ _ v _ < $(SPDK_ROOT_DIR)/VERSION; echo $$v)
 version_suffix := $(shell IFS='-.' read -r _ _ _ v < $(SPDK_ROOT_DIR)/VERSION; echo $${v:+-$$v})
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#9834

#### What this PR does / why we need it:

Fix build error:
```
/usr/src/spdk/mk/spdk.common.mk:584: *** unterminated call to function 'shell': missing ')'.  Stop.
```

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

`None`