### PR TITLE
lvol: do not force removal if blob is busy

### DIFF
--- a/lib/lvol/lvol.c
+++ b/lib/lvol/lvol.c
@@ -1081,6 +1081,12 @@ lvol_delete_blob_cb(void *cb_arg, int lvolerrno)
 	struct spdk_lvol *clone_lvol = req->clone_lvol;
 
 	if (lvolerrno < 0) {
+		if (lvolerrno == -EBUSY) {
+			SPDK_ERRLOG("Error %d deleting lvol %s\n", lvolerrno, lvol->name);
+			req->cb_fn(req->cb_arg, lvolerrno);
+			free(req);
+			return;
+		}
 		SPDK_ERRLOG("Could not remove blob on lvol gracefully - forced removal\n");
 	} else {
 		SPDK_INFOLOG(lvol, "Lvol %s deleted\n", lvol->unique_id);


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/10474

#### What this PR does / why we need it:
When the blob deletion returns with busy error, don't proceed with a forced lvol removal as in other blob's error but simply returns the error to the caller.

#### Special notes for your reviewer:

#### Additional documentation or context
