### PR TITLE
Lvol delete check busy

### DIFF
--- a/include/spdk/blob.h
+++ b/include/spdk/blob.h
@@ -768,6 +768,17 @@ bool spdk_blob_is_thin_provisioned(struct spdk_blob *blob);
 bool spdk_blob_is_esnap_clone(const struct spdk_blob *blob);
 
 /**
+ * Check if blob is locked.
+ *
+ * Tells if an operation is actually locking the blob.
+ *
+ * \param blob Blob.
+ *
+ * \return true if blob is locked.
+ */
+bool spdk_blob_is_locked(const struct spdk_blob *blob);
+
+/**
  * Delete an existing blob from the given blobstore.
  *
  * \param bs blobstore.

--- a/lib/blob/blobstore.c
+++ b/lib/blob/blobstore.c
@@ -9817,6 +9817,13 @@ spdk_blob_is_esnap_clone(const struct spdk_blob *blob)
 	return blob_is_esnap_clone(blob);
 }
 
+bool
+spdk_blob_is_locked(const struct spdk_blob *blob)
+{
+	assert(blob != NULL);
+	return blob->locked_operation_in_progress;
+}
+
 static void
 blob_update_clear_method(struct spdk_blob *blob)
 {

--- a/module/bdev/lvol/vbdev_lvol.c
+++ b/module/bdev/lvol/vbdev_lvol.c
@@ -792,6 +792,13 @@ vbdev_lvol_destroy(struct spdk_lvol *lvol, spdk_lvol_op_complete cb_fn, void *cb
 		return;
 	}
 
+	/* Check if blob is locked by another operation */
+	if (spdk_blob_is_locked(lvol->blob)) {
+		SPDK_ERRLOG("Cannot delete lvol %s, blob is locked\n", lvol->name);
+		cb_fn(cb_arg, -EBUSY);
+		return;
+	}
+
 	_vbdev_lvol_destroy(lvol, cb_fn, cb_arg);
 }
 

--- a/test/unit/lib/bdev/vbdev_lvol.c/vbdev_lvol_ut.c
+++ b/test/unit/lib/bdev/vbdev_lvol.c/vbdev_lvol_ut.c
@@ -60,6 +60,7 @@ DEFINE_STUB(spdk_blob_get_esnap_bs_dev, struct spdk_bs_dev *, (const struct spdk
 DEFINE_STUB(spdk_lvol_is_degraded, bool, (const struct spdk_lvol *lvol), false);
 DEFINE_STUB_V(spdk_bs_free_io_channel, (struct spdk_io_channel *channel));
 DEFINE_STUB(spdk_blob_get_num_allocated_clusters, uint64_t, (struct spdk_blob *blob), 0);
+DEFINE_STUB(spdk_blob_is_locked, bool, (const struct spdk_blob *blob), false);
 
 struct spdk_blob {
 	uint64_t	id;


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue https://github.com/longhorn/longhorn/issues/10474

#### What this PR does / why we need it:
The previous PR https://github.com/longhorn/spdk/pull/48 avoided lvol's force removal when the blob is busy, but at that point the bdev was already been registered and so the lvol is not usable anyway. So I have undo that commit and created a new function, to check if the blob is busy, to be called before to start the lvol deletion process, whose first action is the bdev unregistration.

#### Special notes for your reviewer:

#### Additional documentation or context
