### PR TITLE
Nvmf lvol resize

### DIFF
--- a/lib/nvme/nvme_ctrlr.c
+++ b/lib/nvme/nvme_ctrlr.c
@@ -3285,7 +3285,7 @@ static void
 nvme_ctrlr_queue_async_event(struct spdk_nvme_ctrlr *ctrlr,
 			     const struct spdk_nvme_cpl *cpl)
 {
-	struct  spdk_nvme_ctrlr_aer_completion_list *nvme_event;
+	struct  spdk_nvme_ctrlr_aer_completion *nvme_event;
 	struct spdk_nvme_ctrlr_process *proc;
 
 	/* Add async event to each process objects event list */
@@ -3305,14 +3305,14 @@ nvme_ctrlr_queue_async_event(struct spdk_nvme_ctrlr *ctrlr,
 static void
 nvme_ctrlr_complete_queued_async_events(struct spdk_nvme_ctrlr *ctrlr)
 {
-	struct  spdk_nvme_ctrlr_aer_completion_list  *nvme_event, *nvme_event_tmp;
+	struct  spdk_nvme_ctrlr_aer_completion  *nvme_event, *nvme_event_tmp;
 	struct spdk_nvme_ctrlr_process	*active_proc;
 
 	active_proc = nvme_ctrlr_get_current_process(ctrlr);
 
 	STAILQ_FOREACH_SAFE(nvme_event, &active_proc->async_events, link, nvme_event_tmp) {
 		STAILQ_REMOVE(&active_proc->async_events, nvme_event,
-			      spdk_nvme_ctrlr_aer_completion_list, link);
+			      spdk_nvme_ctrlr_aer_completion, link);
 		nvme_ctrlr_process_async_event(ctrlr, &nvme_event->cpl);
 		spdk_free(nvme_event);
 
@@ -3556,7 +3556,7 @@ nvme_ctrlr_cleanup_process(struct spdk_nvme_ctrlr_process *proc)
 {
 	struct nvme_request	*req, *tmp_req;
 	struct spdk_nvme_qpair	*qpair, *tmp_qpair;
-	struct spdk_nvme_ctrlr_aer_completion_list *event;
+	struct spdk_nvme_ctrlr_aer_completion *event;
 
 	STAILQ_FOREACH_SAFE(req, &proc->active_reqs, stailq, tmp_req) {
 		STAILQ_REMOVE(&proc->active_reqs, req, nvme_request, stailq);

--- a/lib/nvme/nvme_ctrlr.c
+++ b/lib/nvme/nvme_ctrlr.c
@@ -3240,20 +3240,55 @@ nvme_ctrlr_process_async_event_finish(struct spdk_nvme_ctrlr_aer_completion *asy
 }
 
 static void
+nvme_ctrlr_ns_attr_changed_namespaces_updated(void *arg, int status)
+{
+	struct spdk_nvme_ctrlr_aer_completion *async_event = arg;
+	struct spdk_nvme_ctrlr *ctrlr = async_event->ctrlr;
+
+	if (status) {
+		nvme_ctrlr_process_async_event_finish(async_event);
+		return;
+	}
+
+	if (--async_event->ns_count == 0) {
+		nvme_io_msg_ctrlr_update(ctrlr);
+		nvme_ctrlr_process_async_event_finish(async_event);
+	}
+}
+
+static void
+nvme_ctrlr_update_namespaces_async(struct spdk_nvme_ctrlr *ctrlr, nvme_ns_async_cb_fn cb_fn,
+				   void *cb_arg)
+{
+	uint32_t nsid;
+	struct spdk_nvme_ns *ns;
+
+	for (nsid = spdk_nvme_ctrlr_get_first_active_ns(ctrlr);
+	     nsid != 0; nsid = spdk_nvme_ctrlr_get_next_active_ns(ctrlr, nsid)) {
+		ns = spdk_nvme_ctrlr_get_ns(ctrlr, nsid);
+		nvme_ns_construct_async(ns, nsid, ctrlr, cb_fn, cb_arg);
+	}
+}
+
+static void
 nvme_ctrlr_reenumerate_active_ns(void *cb_arg, int status)
 {
 	struct spdk_nvme_ctrlr_aer_completion *async_event = cb_arg;
 	struct spdk_nvme_ctrlr *ctrlr = async_event->ctrlr;
+	uint32_t nsid;
 
 	if (status) {
-		goto out;
+		nvme_ctrlr_process_async_event_finish(async_event);
+		return;
 	}
 
-	nvme_ctrlr_update_namespaces(ctrlr);
-	nvme_io_msg_ctrlr_update(ctrlr);
+	for (nsid = spdk_nvme_ctrlr_get_first_active_ns(ctrlr);
+	     nsid != 0; nsid = spdk_nvme_ctrlr_get_next_active_ns(ctrlr, nsid)) {
+		async_event->ns_count++;
+	}
 
-out:
-	nvme_ctrlr_process_async_event_finish(async_event);
+	nvme_ctrlr_update_namespaces_async(ctrlr, nvme_ctrlr_ns_attr_changed_namespaces_updated,
+					   async_event);
 }
 
 static void

--- a/lib/nvme/nvme_ctrlr.c
+++ b/lib/nvme/nvme_ctrlr.c
@@ -3181,16 +3181,65 @@ nvme_ctrlr_update_namespaces(struct spdk_nvme_ctrlr *ctrlr)
 	}
 }
 
-static int
-nvme_ctrlr_clear_changed_ns_log(struct spdk_nvme_ctrlr *ctrlr)
+static void
+nvme_ctrlr_process_async_event_finish(struct spdk_nvme_ctrlr_aer_completion *async_event)
 {
-	struct nvme_completion_poll_status	*status;
-	int		rc = -ENOMEM;
-	char		*buffer = NULL;
-	uint32_t	nsid;
-	size_t		buf_size = (SPDK_NVME_MAX_CHANGED_NAMESPACES * sizeof(uint32_t));
+	struct spdk_nvme_ctrlr *ctrlr = async_event->ctrlr;
+	struct spdk_nvme_cpl *cpl = &async_event->cpl;
+	struct spdk_nvme_ctrlr_process *active_proc;
+
+	active_proc = nvme_ctrlr_get_current_process(ctrlr);
+	if (active_proc && active_proc->aer_cb_fn) {
+		active_proc->aer_cb_fn(active_proc->aer_cb_arg, cpl);
+	}
+
+	spdk_free(async_event);
+}
+
+static void
+nvme_ctrlr_reenumerate_active_ns(struct spdk_nvme_ctrlr *ctrlr)
+{
+	int rc;
+
+	rc = nvme_ctrlr_identify_active_ns(ctrlr);
+	if (rc) {
+		return;
+	}
+	nvme_ctrlr_update_namespaces(ctrlr);
+	nvme_io_msg_ctrlr_update(ctrlr);
+}
+
+static void
+nvme_ctrlr_clear_changed_ns_log_cb(void *arg, const struct spdk_nvme_cpl *cpl)
+{
+	struct spdk_nvme_ctrlr_aer_completion *async_event = arg;
+	char *buffer = async_event->buffer;
+	struct spdk_nvme_ctrlr *ctrlr = async_event->ctrlr;
+	uint32_t nsid;
+
+	/* only check the case of overflow. */
+	nsid = from_le32(buffer);
+	if (nsid == 0xffffffffu) {
+		NVME_CTRLR_WARNLOG(ctrlr, "changed ns log overflowed.\n");
+	}
+
+	spdk_dma_free(buffer);
+
+	nvme_ctrlr_reenumerate_active_ns(ctrlr);
+
+	nvme_ctrlr_process_async_event_finish(async_event);
+}
+
+static int
+nvme_ctrlr_clear_changed_ns_log(struct spdk_nvme_ctrlr_aer_completion *async_event)
+{
+	struct spdk_nvme_ctrlr	*ctrlr = async_event->ctrlr;
+	int						rc = -ENOMEM;
+	char					*buffer = NULL;
+	size_t					buf_size = (SPDK_NVME_MAX_CHANGED_NAMESPACES * sizeof(uint32_t));
 
 	if (ctrlr->opts.disable_read_changed_ns_list_log_page) {
+		nvme_ctrlr_clear_changed_ns_log_cb(async_event, NULL);
 		return 0;
 	}
 
@@ -3201,66 +3250,37 @@ nvme_ctrlr_clear_changed_ns_log(struct spdk_nvme_ctrlr *ctrlr)
 		return rc;
 	}
 
-	status = calloc(1, sizeof(*status));
-	if (!status) {
-		NVME_CTRLR_ERRLOG(ctrlr, "Failed to allocate status tracker\n");
-		goto free_buffer;
-	}
+	async_event->buffer = buffer;
 
 	rc = spdk_nvme_ctrlr_cmd_get_log_page(ctrlr,
 					      SPDK_NVME_LOG_CHANGED_NS_LIST,
 					      SPDK_NVME_GLOBAL_NS_TAG,
-					      buffer, buf_size, 0,
-					      nvme_completion_poll_cb, status);
+					      async_event->buffer, buf_size, 0,
+					      nvme_ctrlr_clear_changed_ns_log_cb, async_event);
 
 	if (rc) {
 		NVME_CTRLR_ERRLOG(ctrlr, "spdk_nvme_ctrlr_cmd_get_log_page() failed: rc=%d\n", rc);
-		free(status);
-		goto free_buffer;
+		spdk_dma_free(buffer);
 	}
 
-	rc = nvme_wait_for_completion_timeout(ctrlr->adminq, status,
-					      ctrlr->opts.admin_timeout_ms * 1000);
-	if (!status->timed_out) {
-		free(status);
-	}
-
-	if (rc) {
-		NVME_CTRLR_ERRLOG(ctrlr, "wait for spdk_nvme_ctrlr_cmd_get_log_page failed: rc=%d\n", rc);
-		goto free_buffer;
-	}
-
-	/* only check the case of overflow. */
-	nsid = from_le32(buffer);
-	if (nsid == 0xffffffffu) {
-		NVME_CTRLR_WARNLOG(ctrlr, "changed ns log overflowed.\n");
-	}
-
-free_buffer:
-	spdk_dma_free(buffer);
 	return rc;
 }
 
 static void
-nvme_ctrlr_process_async_event(struct spdk_nvme_ctrlr *ctrlr,
-			       const struct spdk_nvme_cpl *cpl)
+nvme_ctrlr_process_async_event(struct spdk_nvme_ctrlr_aer_completion *async_event)
 {
+	struct spdk_nvme_ctrlr *ctrlr = async_event->ctrlr;
+	struct spdk_nvme_cpl *cpl = &async_event->cpl;
 	union spdk_nvme_async_event_completion event;
-	struct spdk_nvme_ctrlr_process *active_proc;
 	int rc;
 
 	event.raw = cpl->cdw0;
 
 	if ((event.bits.async_event_type == SPDK_NVME_ASYNC_EVENT_TYPE_NOTICE) &&
 	    (event.bits.async_event_info == SPDK_NVME_ASYNC_EVENT_NS_ATTR_CHANGED)) {
-		nvme_ctrlr_clear_changed_ns_log(ctrlr);
-
-		rc = nvme_ctrlr_identify_active_ns(ctrlr);
-		if (rc) {
+		if (nvme_ctrlr_clear_changed_ns_log(async_event) == 0) {
 			return;
 		}
-		nvme_ctrlr_update_namespaces(ctrlr);
-		nvme_io_msg_ctrlr_update(ctrlr);
 	}
 
 	if ((event.bits.async_event_type == SPDK_NVME_ASYNC_EVENT_TYPE_NOTICE) &&
@@ -3275,10 +3295,7 @@ nvme_ctrlr_process_async_event(struct spdk_nvme_ctrlr *ctrlr,
 		}
 	}
 
-	active_proc = nvme_ctrlr_get_current_process(ctrlr);
-	if (active_proc && active_proc->aer_cb_fn) {
-		active_proc->aer_cb_fn(active_proc->aer_cb_arg, cpl);
-	}
+	nvme_ctrlr_process_async_event_finish(async_event);
 }
 
 static void
@@ -3296,6 +3313,7 @@ nvme_ctrlr_queue_async_event(struct spdk_nvme_ctrlr *ctrlr,
 			NVME_CTRLR_ERRLOG(ctrlr, "Alloc nvme event failed, ignore the event\n");
 			return;
 		}
+		nvme_event->ctrlr = ctrlr;
 		nvme_event->cpl = *cpl;
 
 		STAILQ_INSERT_TAIL(&proc->async_events, nvme_event, link);
@@ -3313,9 +3331,7 @@ nvme_ctrlr_complete_queued_async_events(struct spdk_nvme_ctrlr *ctrlr)
 	STAILQ_FOREACH_SAFE(nvme_event, &active_proc->async_events, link, nvme_event_tmp) {
 		STAILQ_REMOVE(&active_proc->async_events, nvme_event,
 			      spdk_nvme_ctrlr_aer_completion, link);
-		nvme_ctrlr_process_async_event(ctrlr, &nvme_event->cpl);
-		spdk_free(nvme_event);
-
+		nvme_ctrlr_process_async_event(nvme_event);
 	}
 }
 

--- a/lib/nvme/nvme_ctrlr.c
+++ b/lib/nvme/nvme_ctrlr.c
@@ -2295,6 +2295,7 @@ enum nvme_active_ns_state {
 };
 
 typedef void (*nvme_active_ns_ctx_deleter)(struct nvme_active_ns_ctx *);
+typedef void (*nvme_active_ns_cb_fn)(void *cb_arg, int status);
 
 struct nvme_active_ns_ctx {
 	struct spdk_nvme_ctrlr *ctrlr;
@@ -2302,6 +2303,8 @@ struct nvme_active_ns_ctx {
 	uint32_t next_nsid;
 	uint32_t *new_ns_list;
 	nvme_active_ns_ctx_deleter deleter;
+	nvme_active_ns_cb_fn cb_fn;
+	void *cb_arg;
 
 	enum nvme_active_ns_state state;
 };
@@ -2438,9 +2441,11 @@ nvme_ctrlr_identify_active_ns_async_done(void *arg, const struct spdk_nvme_cpl *
 {
 	struct nvme_active_ns_ctx *ctx = arg;
 	uint32_t *new_ns_list = NULL;
+	int rc = 0;
 
 	if (spdk_nvme_cpl_is_error(cpl)) {
 		ctx->state = NVME_ACTIVE_NS_STATE_ERROR;
+		rc = -ENXIO;
 		goto out;
 	}
 
@@ -2457,6 +2462,7 @@ nvme_ctrlr_identify_active_ns_async_done(void *arg, const struct spdk_nvme_cpl *
 	if (!new_ns_list) {
 		SPDK_ERRLOG("Failed to reallocate active_ns_list!\n");
 		ctx->state = NVME_ACTIVE_NS_STATE_ERROR;
+		rc = -ENOMEM;
 		goto out;
 	}
 
@@ -2465,6 +2471,9 @@ nvme_ctrlr_identify_active_ns_async_done(void *arg, const struct spdk_nvme_cpl *
 	return;
 
 out:
+	if (ctx->cb_fn) {
+		ctx->cb_fn(ctx->cb_arg, rc);
+	}
 	if (ctx->deleter) {
 		ctx->deleter(ctx);
 	}
@@ -2534,6 +2543,22 @@ out:
 }
 
 static void
+_nvme_active_ns_ctx_deleter_async(struct nvme_active_ns_ctx *ctx)
+{
+	struct spdk_nvme_ctrlr *ctrlr = ctx->ctrlr;
+
+	if (ctx->state == NVME_ACTIVE_NS_STATE_ERROR) {
+		nvme_active_ns_ctx_destroy(ctx);
+		return;
+	}
+
+	assert(ctx->state == NVME_ACTIVE_NS_STATE_DONE);
+
+	nvme_ctrlr_identify_active_ns_swap(ctrlr, ctx->new_ns_list, ctx->page_count * 1024);
+	nvme_active_ns_ctx_destroy(ctx);
+}
+
+static void
 _nvme_active_ns_ctx_deleter(struct nvme_active_ns_ctx *ctx)
 {
 	struct spdk_nvme_ctrlr *ctrlr = ctx->ctrlr;
@@ -2554,6 +2579,24 @@ _nvme_active_ns_ctx_deleter(struct nvme_active_ns_ctx *ctx)
 	nvme_ctrlr_identify_active_ns_swap(ctrlr, ctx->new_ns_list, ctx->page_count * 1024);
 	nvme_active_ns_ctx_destroy(ctx);
 	nvme_ctrlr_set_state(ctrlr, NVME_CTRLR_STATE_IDENTIFY_NS, ctrlr->opts.admin_timeout_ms);
+}
+
+static void
+_nvme_ctrlr_identify_active_ns_async(struct spdk_nvme_ctrlr *ctrlr, nvme_active_ns_cb_fn cb_fn,
+				     void *cb_arg)
+{
+	struct nvme_active_ns_ctx *ctx;
+
+	ctx = nvme_active_ns_ctx_create(ctrlr, _nvme_active_ns_ctx_deleter_async);
+	if (!ctx) {
+		cb_fn(cb_arg, -ENOMEM);
+		return;
+	}
+
+	ctx->cb_fn = cb_fn;
+	ctx->cb_arg = cb_arg;
+
+	nvme_ctrlr_identify_active_ns_async(ctx);
 }
 
 static void
@@ -3197,16 +3240,20 @@ nvme_ctrlr_process_async_event_finish(struct spdk_nvme_ctrlr_aer_completion *asy
 }
 
 static void
-nvme_ctrlr_reenumerate_active_ns(struct spdk_nvme_ctrlr *ctrlr)
+nvme_ctrlr_reenumerate_active_ns(void *cb_arg, int status)
 {
-	int rc;
+	struct spdk_nvme_ctrlr_aer_completion *async_event = cb_arg;
+	struct spdk_nvme_ctrlr *ctrlr = async_event->ctrlr;
 
-	rc = nvme_ctrlr_identify_active_ns(ctrlr);
-	if (rc) {
-		return;
+	if (status) {
+		goto out;
 	}
+
 	nvme_ctrlr_update_namespaces(ctrlr);
 	nvme_io_msg_ctrlr_update(ctrlr);
+
+out:
+	nvme_ctrlr_process_async_event_finish(async_event);
 }
 
 static void
@@ -3225,9 +3272,7 @@ nvme_ctrlr_clear_changed_ns_log_cb(void *arg, const struct spdk_nvme_cpl *cpl)
 
 	spdk_dma_free(buffer);
 
-	nvme_ctrlr_reenumerate_active_ns(ctrlr);
-
-	nvme_ctrlr_process_async_event_finish(async_event);
+	_nvme_ctrlr_identify_active_ns_async(ctrlr, nvme_ctrlr_reenumerate_active_ns, async_event);
 }
 
 static int

--- a/lib/nvme/nvme_internal.h
+++ b/lib/nvme/nvme_internal.h
@@ -876,9 +876,9 @@ enum nvme_ctrlr_state {
 #define NVME_TIMEOUT_INFINITE		0
 #define NVME_TIMEOUT_KEEP_EXISTING	UINT64_MAX
 
-struct spdk_nvme_ctrlr_aer_completion_list {
+struct spdk_nvme_ctrlr_aer_completion {
 	struct spdk_nvme_cpl	cpl;
-	STAILQ_ENTRY(spdk_nvme_ctrlr_aer_completion_list) link;
+	STAILQ_ENTRY(spdk_nvme_ctrlr_aer_completion) link;
 };
 
 /*
@@ -918,7 +918,7 @@ struct spdk_nvme_ctrlr_process {
 	uint64_t			timeout_admin_ticks;
 
 	/** List to publish AENs to all procs in multiprocess setup */
-	STAILQ_HEAD(, spdk_nvme_ctrlr_aer_completion_list)      async_events;
+	STAILQ_HEAD(, spdk_nvme_ctrlr_aer_completion)      async_events;
 };
 
 struct nvme_register_completion {

--- a/lib/nvme/nvme_internal.h
+++ b/lib/nvme/nvme_internal.h
@@ -1222,6 +1222,8 @@ int nvme_poll_group_connect_qpair(struct spdk_nvme_qpair *qpair);
 int nvme_poll_group_disconnect_qpair(struct spdk_nvme_qpair *qpair);
 
 /* Admin functions */
+typedef void (*nvme_ns_async_cb_fn)(void *cb_arg, int status);
+
 int	nvme_ctrlr_cmd_identify(struct spdk_nvme_ctrlr *ctrlr,
 				uint8_t cns, uint16_t cntid, uint32_t nsid,
 				uint8_t csi, void *payload, size_t payload_size,
@@ -1332,6 +1334,9 @@ void	nvme_ns_free_iocs_specific_data(struct spdk_nvme_ns *ns);
 bool	nvme_ns_has_supported_iocs_specific_data(struct spdk_nvme_ns *ns);
 int	nvme_ns_construct(struct spdk_nvme_ns *ns, uint32_t id,
 			  struct spdk_nvme_ctrlr *ctrlr);
+int	nvme_ns_construct_async(struct spdk_nvme_ns *ns, uint32_t id,
+				struct spdk_nvme_ctrlr *ctrlr,
+				nvme_ns_async_cb_fn cb_fn, void *cb_arg);
 void	nvme_ns_destruct(struct spdk_nvme_ns *ns);
 int	nvme_ns_cmd_zone_append_with_md(struct spdk_nvme_ns *ns, struct spdk_nvme_qpair *qpair,
 					void *buffer, void *metadata, uint64_t zslba,

--- a/lib/nvme/nvme_internal.h
+++ b/lib/nvme/nvme_internal.h
@@ -877,7 +877,21 @@ enum nvme_ctrlr_state {
 #define NVME_TIMEOUT_KEEP_EXISTING	UINT64_MAX
 
 struct spdk_nvme_ctrlr_aer_completion {
+	struct spdk_nvme_ctrlr	*ctrlr;
 	struct spdk_nvme_cpl	cpl;
+
+	/*
+	 * Pointer to the payload buffer for the get log page command to be
+	 * executed in the async handling of this completion event.
+	 */
+	char			*buffer;
+
+	/*
+	 * Counter to be used in the update of active namespaces to keep track
+	 * of how many ns construct executions have been started.
+	 */
+	uint32_t		ns_count;
+
 	STAILQ_ENTRY(spdk_nvme_ctrlr_aer_completion) link;
 };
 

--- a/test/unit/lib/nvme/nvme_ctrlr.c/nvme_ctrlr_ut.c
+++ b/test/unit/lib/nvme/nvme_ctrlr.c/nvme_ctrlr_ut.c
@@ -696,6 +696,15 @@ nvme_ns_construct(struct spdk_nvme_ns *ns, uint32_t id,
 	return 0;
 }
 
+int
+nvme_ns_construct_async(struct spdk_nvme_ns *ns, uint32_t id,
+			struct spdk_nvme_ctrlr *ctrlr,
+			nvme_ns_async_cb_fn cb_fn, void *cb_arg)
+{
+	cb_fn(cb_arg, 0);
+	return 0;
+}
+
 void
 spdk_pci_device_detach(struct spdk_pci_device *device)
 {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue https://github.com/longhorn/longhorn/issues/8022

#### What this PR does / why we need it:
When we have a local replica, we don't use it directly as base bdev for the raid1, but we export it via nvmf and then attach to it via nvme controller. If we resize the lvol, the operation get stuck in the nvme controller because the same poller is used for the nvmf export side and the nvme attach side. This is due to some operation inside the `nvme_ctrl` that are done synchronously, so the solution is to make all these operations fully asynchronous.

#### Special notes for your reviewer:

#### Additional documentation or context
