### PR TITLE
nvme/tcp: enable interrupt mode support for TCP transport

### DIFF
--- a/app/spdk_tgt/Makefile
+++ b/app/spdk_tgt/Makefile
@@ -13,7 +13,11 @@ C_SRCS := spdk_tgt.c
 
 SPDK_LIB_LIST = $(ALL_MODULES_LIST)
 
-SPDK_LIB_LIST += event event_iscsi event_nvmf
+# The iSCSI subsystem is not used in Longhorn V2. To support interrupt mode,
+# Exclude event_iscsi from SPDK_LIB_LIST to prevent its initialization.
+#
+# SPDK_LIB_LIST += event event_iscsi event_nvmf
+SPDK_LIB_LIST += event event_nvmf
 
 ifeq ($(SPDK_ROOT_DIR)/lib/env_dpdk,$(CONFIG_ENV))
 SPDK_LIB_LIST += env_dpdk_rpc

--- a/examples/vmd/led/Makefile
+++ b/examples/vmd/led/Makefile
@@ -11,6 +11,6 @@ APP = led
 
 C_SRCS := led.c
 
-SPDK_LIB_LIST = vmd log util nvme
+SPDK_LIB_LIST = vmd log util nvme thread
 
 include $(SPDK_ROOT_DIR)/mk/spdk.app.mk

--- a/examples/vmd/lsvmd/Makefile
+++ b/examples/vmd/lsvmd/Makefile
@@ -11,6 +11,6 @@ APP = lsvmd
 
 C_SRCS := lsvmd.c
 
-SPDK_LIB_LIST = vmd log util nvme
+SPDK_LIB_LIST = vmd log util nvme thread
 
 include $(SPDK_ROOT_DIR)/mk/spdk.app.mk

--- a/include/spdk/sock.h
+++ b/include/spdk/sock.h
@@ -710,6 +710,14 @@ int spdk_sock_group_poll_count(struct spdk_sock_group *group, int max_events);
 int spdk_sock_group_close(struct spdk_sock_group **group);
 
 /**
+ * Retrieve the file descriptor associated with a given SPDK socket.
+ *
+ * @param sock Pointer to an spdk_sock structure representing the socket.
+ * @return The file descriptor of the socket on success, or -1 on failure.
+ */
+int spdk_get_sock_fd(struct spdk_sock *sock);
+
+/**
  * Get the optimal sock group for this sock.
  *
  * This function is allowed only when connection is established.

--- a/include/spdk_internal/sock_module.h
+++ b/include/spdk_internal/sock_module.h
@@ -119,6 +119,7 @@ struct spdk_net_impl {
 
 	int (*get_opts)(struct spdk_sock_impl_opts *opts, size_t *len);
 	int (*set_opts)(const struct spdk_sock_impl_opts *opts, size_t len);
+	int (*get_fd)(struct spdk_sock *sock);
 
 	STAILQ_ENTRY(spdk_net_impl) link;
 };
@@ -386,6 +387,14 @@ spdk_sock_get_placement_id(int fd, enum spdk_placement_mode mode, int *placement
 		break;
 	}
 }
+
+/**
+ * Retrieve the file descriptor associated with a given SPDK socket.
+ *
+ * @param sock Pointer to an spdk_sock structure representing the socket.
+ * @return The file descriptor of the socket on success, or a negative value on failure.
+ */
+int spdk_get_sock_fd(struct spdk_sock *sock);
 
 /**
  * Converts ip and port into address.

--- a/lib/nvme/nvme_tcp.c
+++ b/lib/nvme/nvme_tcp.c
@@ -1002,6 +1002,34 @@ nvme_tcp_qpair_reset(struct spdk_nvme_qpair *qpair)
 	return 0;
 }
 
+static int
+nvme_tcp_qpair_get_fd(struct spdk_nvme_qpair *qpair, struct spdk_event_handler_opts *opts)
+{
+	struct spdk_nvme_ctrlr *ctrlr = qpair->ctrlr;
+	struct nvme_tcp_qpair *tqpair;
+	int fd;
+
+	if (!ctrlr->opts.enable_interrupts) {
+		return -1;
+	}
+
+	if (!qpair) {
+        return -EINVAL;
+    }
+
+    tqpair = nvme_tcp_qpair(qpair);  // Convert generic qpair to TCP qpair
+    if (!tqpair || !tqpair->sock) {
+        return -EINVAL;
+    }
+
+	fd = spdk_get_sock_fd(tqpair->sock);
+	if (fd < 0) {
+		return -EINVAL;
+	}
+
+	return fd;
+}
+
 static void
 nvme_tcp_req_complete(struct nvme_tcp_req *tcp_req,
 		      struct nvme_tcp_qpair *tqpair,
@@ -2671,6 +2699,11 @@ nvme_tcp_ctrlr_get_max_sges(struct spdk_nvme_ctrlr *ctrlr)
 	return NVME_TCP_MAX_SGL_DESCRIPTORS;
 }
 
+static int nvme_tcp_ctrlr_enable_interrupts(struct spdk_nvme_ctrlr *ctrlr)
+{
+    return 0;
+}
+
 static int
 nvme_tcp_qpair_iterate_requests(struct spdk_nvme_qpair *qpair,
 				int (*iter_fn)(struct nvme_request *req, void *arg),
@@ -2905,6 +2938,11 @@ static void
 nvme_tcp_poll_group_check_disconnected_qpairs(struct spdk_nvme_transport_poll_group *tgroup,
 		spdk_nvme_disconnected_qpair_cb disconnected_qpair_cb)
 {
+	struct spdk_nvme_qpair *qpair, *tmp_qpair;
+
+	STAILQ_FOREACH_SAFE(qpair, &tgroup->disconnected_qpairs, poll_group_stailq, tmp_qpair) {
+		disconnected_qpair_cb(qpair, tgroup->group->ctx);
+	}
 }
 
 static int
@@ -2980,6 +3018,7 @@ const struct spdk_nvme_transport_ops tcp_ops = {
 	.ctrlr_scan = nvme_fabric_ctrlr_scan,
 	.ctrlr_destruct = nvme_tcp_ctrlr_destruct,
 	.ctrlr_enable = nvme_tcp_ctrlr_enable,
+	.ctrlr_enable_interrupts = nvme_tcp_ctrlr_enable_interrupts,
 
 	.ctrlr_set_reg_4 = nvme_fabric_ctrlr_set_reg_4,
 	.ctrlr_set_reg_8 = nvme_fabric_ctrlr_set_reg_8,
@@ -3006,6 +3045,7 @@ const struct spdk_nvme_transport_ops tcp_ops = {
 	.qpair_process_completions = nvme_tcp_qpair_process_completions,
 	.qpair_iterate_requests = nvme_tcp_qpair_iterate_requests,
 	.qpair_authenticate = nvme_tcp_qpair_authenticate,
+	.qpair_get_fd = nvme_tcp_qpair_get_fd,
 	.admin_qpair_abort_aers = nvme_tcp_admin_qpair_abort_aers,
 
 	.poll_group_create = nvme_tcp_poll_group_create,

--- a/lib/nvme/nvme_transport.c
+++ b/lib/nvme/nvme_transport.c
@@ -11,6 +11,7 @@
 
 #include "nvme_internal.h"
 #include "spdk/queue.h"
+#include "spdk/thread.h"
 
 #define SPDK_MAX_NUM_OF_TRANSPORTS 16
 
@@ -493,6 +494,95 @@ nvme_transport_connect_qpair_fail(struct spdk_nvme_qpair *qpair, void *unused)
 	nvme_transport_ctrlr_disconnect_qpair(ctrlr, qpair);
 }
 
+typedef void (*connect_complete_cb)(struct spdk_nvme_qpair *qpair, int status, void *cb_arg);
+
+struct connect_ctx {
+    struct spdk_nvme_qpair *qpair;
+    struct spdk_nvme_poll_group *poll_group;
+    struct spdk_poller *poller;
+
+    connect_complete_cb cb_fn;
+    void *cb_arg;
+};
+
+static void
+nvme_connect_complete(struct connect_ctx *ctx, int status)
+{
+    if (ctx->cb_fn) {
+        ctx->cb_fn(ctx->qpair, status, ctx->cb_arg);
+    }
+
+    spdk_poller_unregister(&ctx->poller);
+    free(ctx);
+}
+
+static int
+nvme_connect_poller(void *arg)
+{
+    struct connect_ctx *ctx = arg;
+    struct spdk_nvme_qpair *qpair = ctx->qpair;
+    int rc;
+
+    if (ctx->poll_group && spdk_nvme_ctrlr_is_fabrics(qpair->ctrlr)) {
+        rc = spdk_nvme_poll_group_process_completions(ctx->poll_group, 0,
+                                                      nvme_transport_connect_qpair_fail);
+    } else {
+        rc = spdk_nvme_qpair_process_completions(qpair, 0);
+    }
+
+    if (rc < 0) {
+        nvme_connect_complete(ctx, rc);
+        return SPDK_POLLER_BUSY;
+    }
+
+    if (nvme_qpair_get_state(qpair) != NVME_QPAIR_CONNECTING) {
+        nvme_connect_complete(ctx, 0);
+        return SPDK_POLLER_BUSY;
+    }
+
+    return SPDK_POLLER_BUSY;
+}
+
+int
+start_async_qpair_connect(struct spdk_nvme_qpair *qpair,
+                          connect_complete_cb cb_fn,
+                          void *cb_arg)
+{
+    struct connect_ctx *ctx;
+
+    if (!qpair || !qpair->poll_group) {
+        return -EINVAL;
+    }
+
+    ctx = calloc(1, sizeof(*ctx));
+    if (!ctx) {
+        return -ENOMEM;
+    }
+
+    ctx->qpair = qpair;
+    ctx->poll_group = qpair->poll_group->group;
+    ctx->cb_fn = cb_fn;
+    ctx->cb_arg = cb_arg;
+
+    ctx->poller = spdk_poller_register(nvme_connect_poller, ctx, 1000 /* 1ms */);
+    if (!ctx->poller) {
+        free(ctx);
+        return -ENOMEM;
+    }
+
+    return 0;
+}
+
+static void
+nvme_qpair_connect_completion_cb(struct spdk_nvme_qpair *qpair, int status, void *cb_arg)
+{
+    if (status == 0) {
+        SPDK_NOTICELOG("NVMe qpair %p connected successfully.\n", (void *)qpair);
+    } else {
+        SPDK_ERRLOG("Failed to connect NVMe qpair %p (status: %d).\n", (void *)qpair, status);
+    }
+}
+
 int
 nvme_transport_ctrlr_connect_qpair(struct spdk_nvme_ctrlr *ctrlr, struct spdk_nvme_qpair *qpair)
 {
@@ -523,25 +613,31 @@ nvme_transport_ctrlr_connect_qpair(struct spdk_nvme_ctrlr *ctrlr, struct spdk_nv
 		}
 	}
 
-	/* For the TCP transport, we poll the I/O queue periodically using g_opts.nvme_ioq_poll_period_us,
-	 * and do no wait synchronously for the qpair to connect. This allows the NVMe-oF
-	 * initiator to send the command and gives the target an opportunity to process
-	 * and respond without blocking. This unblocks when the initiator and target
-	 * are running on the same host.
-	 */
-	if (!qpair->async && (ctrlr->trid.trtype != SPDK_NVME_TRANSPORT_TCP)) {
-		/* Busy wait until the qpair exits the connecting state */
-		while (nvme_qpair_get_state(qpair) == NVME_QPAIR_CONNECTING) {
-			if (qpair->poll_group && spdk_nvme_ctrlr_is_fabrics(ctrlr)) {
-				rc = spdk_nvme_poll_group_process_completions(
-					     qpair->poll_group->group, 0,
-					     nvme_transport_connect_qpair_fail);
-			} else {
-				rc = spdk_nvme_qpair_process_completions(qpair, 0);
-			}
+	if (!qpair->async) {
+		if (ctrlr->trid.trtype != SPDK_NVME_TRANSPORT_TCP) {
+			/* Busy wait until the qpair exits the connecting state */
+			while (nvme_qpair_get_state(qpair) == NVME_QPAIR_CONNECTING) {
+				if (qpair->poll_group && spdk_nvme_ctrlr_is_fabrics(ctrlr)) {
+					rc = spdk_nvme_poll_group_process_completions(
+							qpair->poll_group->group, 0,
+						    nvme_transport_connect_qpair_fail);
+				} else {
+					rc = spdk_nvme_qpair_process_completions(qpair, 0);
+				}
 
-			if (rc < 0) {
-				goto err;
+				if (rc < 0) {
+					goto err;
+				}
+			}
+		} else {
+			/*
+			 * Non-blocking path for TCP transport. Use a poller to complete connection
+			 * asynchronously.
+			 */
+			rc = start_async_qpair_connect(qpair, nvme_qpair_connect_completion_cb, NULL);
+			if (rc != 0) {
+			    SPDK_ERRLOG("Failed to start async connect: %d\n", rc);
+			    goto err;
 			}
 		}
 	}

--- a/lib/nvme/nvme_transport.c
+++ b/lib/nvme/nvme_transport.c
@@ -523,7 +523,13 @@ nvme_transport_ctrlr_connect_qpair(struct spdk_nvme_ctrlr *ctrlr, struct spdk_nv
 		}
 	}
 
-	if (!qpair->async) {
+	/* For the TCP transport, we poll the I/O queue periodically using g_opts.nvme_ioq_poll_period_us,
+	 * and do no wait synchronously for the qpair to connect. This allows the NVMe-oF
+	 * initiator to send the command and gives the target an opportunity to process
+	 * and respond without blocking. This unblocks when the initiator and target
+	 * are running on the same host.
+	 */
+	if (!qpair->async && (ctrlr->trid.trtype != SPDK_NVME_TRANSPORT_TCP)) {
 		/* Busy wait until the qpair exits the connecting state */
 		while (nvme_qpair_get_state(qpair) == NVME_QPAIR_CONNECTING) {
 			if (qpair->poll_group && spdk_nvme_ctrlr_is_fabrics(ctrlr)) {

--- a/lib/nvme/nvme_transport.c
+++ b/lib/nvme/nvme_transport.c
@@ -513,7 +513,10 @@ nvme_transport_ctrlr_connect_qpair(struct spdk_nvme_ctrlr *ctrlr, struct spdk_nv
 		goto err;
 	}
 
-	if (qpair->poll_group) {
+	/* Skip TCP I/O queue pair registration since it's already handled in
+	 * nvme_transport_connect_qpair.
+	 */
+	if (qpair->poll_group && (ctrlr->trid.trtype != SPDK_NVME_TRANSPORT_TCP)) {
 		rc = nvme_poll_group_connect_qpair(qpair);
 		if (rc) {
 			goto err;

--- a/lib/sock/sock.c
+++ b/lib/sock/sock.c
@@ -206,6 +206,11 @@ spdk_sock_map_find_free(struct spdk_sock_map *map)
 }
 
 int
+spdk_get_sock_fd(struct spdk_sock *sock) {
+	return sock->net_impl->get_fd(sock);
+}
+
+int
 spdk_sock_get_optimal_sock_group(struct spdk_sock *sock, struct spdk_sock_group **group,
 				 struct spdk_sock_group *hint)
 {

--- a/module/bdev/nvme/bdev_nvme.c
+++ b/module/bdev/nvme/bdev_nvme.c
@@ -5986,12 +5986,21 @@ nvme_ctrlr_create(struct spdk_nvme_ctrlr *ctrlr,
 		spdk_bdev_nvme_get_default_ctrlr_opts(&nvme_ctrlr->opts);
 	}
 
-	/* In interrupt mode, NVMe/TCP requires periodic polling of the admin queue
-	* to ensure timely Keep Alive command completion. Unlike PCIe, TCP transport
-	* does not provide hardware interrupts for admin completions.
-	*/
-	period = (spdk_interrupt_mode_is_enabled() && (g_nvme_trtype != SPDK_NVME_TRANSPORT_TCP)) ? 0 : g_opts.nvme_adminq_poll_period_us;
+	period = spdk_interrupt_mode_is_enabled() ? 0 : g_opts.nvme_adminq_poll_period_us;
+	/*
+	 * In interrupt mode, NVMe/TCP requires periodic polling of the admin queue
+	 * to ensure timely Keep Alive and disconnect handling. TCP transport does not
+	 * provide hardware interrupts for admin completions.
+	 *
+	 * To prevent a race condition where IOQs detect socket closure before adminq
+	 * wakes up (causing commands to be issued on a closed socket, EBADF), we force
+	 * a shorter admin queue poll period for NVMe/TCP in interrupt mode.
+	 *
+	 * This should ideally match or be shorter than nvme_ioq_poll_period_us.
+	 */
+	period = (spdk_interrupt_mode_is_enabled() && (g_nvme_trtype != SPDK_NVME_TRANSPORT_TCP)) ? period : 100;
 
+	SPDK_DEBUGLOG(bdev_nvme, "Registering admin poller for controller with poll period %" PRIu64 "\n", period);
 	nvme_ctrlr->adminq_timer_poller = SPDK_POLLER_REGISTER(bdev_nvme_poll_adminq, nvme_ctrlr,
 					  period);
 

--- a/module/bdev/nvme/bdev_nvme.c
+++ b/module/bdev/nvme/bdev_nvme.c
@@ -5986,12 +5986,16 @@ nvme_ctrlr_create(struct spdk_nvme_ctrlr *ctrlr,
 		spdk_bdev_nvme_get_default_ctrlr_opts(&nvme_ctrlr->opts);
 	}
 
-	period = spdk_interrupt_mode_is_enabled() ? 0 : g_opts.nvme_adminq_poll_period_us;
+	/* In interrupt mode, NVMe/TCP requires periodic polling of the admin queue
+	* to ensure timely Keep Alive command completion. Unlike PCIe, TCP transport
+	* does not provide hardware interrupts for admin completions.
+	*/
+	period = (spdk_interrupt_mode_is_enabled() && (g_nvme_trtype != SPDK_NVME_TRANSPORT_TCP)) ? 0 : g_opts.nvme_adminq_poll_period_us;
 
 	nvme_ctrlr->adminq_timer_poller = SPDK_POLLER_REGISTER(bdev_nvme_poll_adminq, nvme_ctrlr,
 					  period);
 
-	if (spdk_interrupt_mode_is_enabled()) {
+	if (spdk_interrupt_mode_is_enabled() && (g_nvme_trtype != SPDK_NVME_TRANSPORT_TCP)){
 		spdk_poller_register_interrupt(nvme_ctrlr->adminq_timer_poller, NULL, NULL);
 
 		fd = spdk_nvme_ctrlr_get_admin_qp_fd(nvme_ctrlr->ctrlr, &opts);

--- a/module/bdev/nvme/bdev_nvme.c
+++ b/module/bdev/nvme/bdev_nvme.c
@@ -6768,10 +6768,11 @@ spdk_bdev_nvme_create(struct spdk_nvme_transport_id *trid,
 	ctx->drv_opts.transport_tos = g_opts.transport_tos;
 
 	if (spdk_interrupt_mode_is_enabled()) {
-		if (trid->trtype == SPDK_NVME_TRANSPORT_PCIE) {
+		if (trid->trtype == SPDK_NVME_TRANSPORT_PCIE ||
+		    trid->trtype == SPDK_NVME_TRANSPORT_TCP) {
 			ctx->drv_opts.enable_interrupts = true;
 		} else {
-			SPDK_ERRLOG("Interrupt mode is only supported with PCIe transport\n");
+			SPDK_ERRLOG("Interrupt mode is only supported with PCIe and TCP transports\n");
 			free_nvme_async_probe_ctx(ctx);
 			return -ENOTSUP;
 		}

--- a/module/bdev/nvme/bdev_nvme.c
+++ b/module/bdev/nvme/bdev_nvme.c
@@ -200,6 +200,7 @@ struct spdk_thread *g_bdev_nvme_init_thread;
 static struct spdk_poller *g_hotplug_poller;
 static struct spdk_poller *g_hotplug_probe_poller;
 static struct spdk_nvme_probe_ctx *g_hotplug_probe_ctx;
+static enum spdk_nvme_transport_type g_nvme_trtype = SPDK_NVME_TRANSPORT_CUSTOM;
 
 static void nvme_ctrlr_populate_namespaces(struct nvme_ctrlr *nvme_ctrlr,
 		struct nvme_async_probe_ctx *ctx);
@@ -3797,6 +3798,17 @@ bdev_nvme_create_poll_group_cb(void *io_device, void *ctx_buf)
 	}
 
 	period = spdk_interrupt_mode_is_enabled() ? 0 : g_opts.nvme_ioq_poll_period_us;
+	if (spdk_interrupt_mode_is_enabled() && (g_nvme_trtype == SPDK_NVME_TRANSPORT_TCP)) {
+		/* For TCP transport in interrupt mode, the IO queue must be polled periodically
+		 * to flush data. Since TCP transport does not automatically push data to
+		 * the OS stack, we poll periodically to ensure timely processing of IO
+		 * commands.
+		 *
+		 * Unit is in milliseconds.
+		 * https://github.com/spdk/spdk/blob/3cb3145bfa22a650a01c1183332a9f8c5bd2f868/doc/jsonrpc.md?plain=1#L3995
+		 */
+		period = 100;
+	}
 	group->poller = SPDK_POLLER_REGISTER(bdev_nvme_poll, group, period);
 
 	if (group->poller == NULL) {
@@ -3804,7 +3816,10 @@ bdev_nvme_create_poll_group_cb(void *io_device, void *ctx_buf)
 		return -1;
 	}
 
-	if (spdk_interrupt_mode_is_enabled()) {
+	/* Skip interrupt registration for TCP transport as it still requires periodic
+	 * polling to check and flush the IO queue.
+	 */
+	if (spdk_interrupt_mode_is_enabled() && g_nvme_trtype != SPDK_NVME_TRANSPORT_TCP) {
 		spdk_poller_register_interrupt(group->poller, NULL, NULL);
 
 		fgrp = spdk_nvme_poll_group_get_fd_group(group->group);
@@ -6713,6 +6728,14 @@ spdk_bdev_nvme_create(struct spdk_nvme_transport_id *trid,
 		SPDK_ERRLOG("A controller with the provided trid (traddr: %s, hostnqn: %s) "
 			    "already exists.\n", trid->traddr, drv_opts->hostnqn);
 		return -EEXIST;
+	}
+
+	if (g_nvme_trtype == SPDK_NVME_TRANSPORT_CUSTOM) {
+		g_nvme_trtype = trid->trtype;
+	} else if (g_nvme_trtype != trid->trtype) {
+		SPDK_ERRLOG("NVMe transport type %s is not supported.\n",
+			    spdk_nvme_transport_id_trtype_str(trid->trtype));
+		return -ENOTSUP;
 	}
 
 	len = strnlen(base_name, SPDK_CONTROLLER_NAME_MAX);

--- a/module/sock/posix/posix.c
+++ b/module/sock/posix/posix.c
@@ -188,6 +188,12 @@ _sock_impl_get_opts(struct spdk_sock_impl_opts *opts, struct spdk_sock_impl_opts
 }
 
 static int
+posix_sock_get_fd(struct spdk_sock *sock) {
+	struct spdk_posix_sock *posix_sock = __posix_sock(sock);
+	return posix_sock->fd;
+}
+
+static int
 posix_sock_impl_get_opts(struct spdk_sock_impl_opts *opts, size_t *len)
 {
 	return _sock_impl_get_opts(opts, &g_posix_impl_opts, len);
@@ -2456,6 +2462,7 @@ static struct spdk_net_impl g_posix_net_impl = {
 	.group_impl_close	= posix_sock_group_impl_close,
 	.get_opts	= posix_sock_impl_get_opts,
 	.set_opts	= posix_sock_impl_set_opts,
+	.get_fd 	= posix_sock_get_fd,
 };
 
 SPDK_NET_IMPL_REGISTER_DEFAULT(posix, &g_posix_net_impl);

--- a/test/unit/lib/nvme/nvme_tcp.c/nvme_tcp_ut.c
+++ b/test/unit/lib/nvme/nvme_tcp.c/nvme_tcp_ut.c
@@ -39,6 +39,7 @@ DEFINE_STUB(spdk_sock_group_get_ctx,
 	    (struct spdk_sock_group *group),
 	    NULL);
 DEFINE_STUB(spdk_sock_get_numa_id, int32_t, (struct spdk_sock *sock), SPDK_ENV_NUMA_ID_ANY);
+DEFINE_STUB(spdk_get_sock_fd, int, (struct spdk_sock *sock), 0);
 
 DEFINE_STUB(spdk_nvme_poll_group_process_completions, int64_t, (struct spdk_nvme_poll_group *group,
 		uint32_t completions_per_qpair, spdk_nvme_disconnected_qpair_cb disconnected_qpair_cb), 0);


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#9834

#### What this PR does / why we need it:

Support interrupt mode for NVMe TCP transport.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

https://github.com/longhorn/longhorn/issues/9834#issuecomment-2914384232