### PR TITLE
Implement `bdev_lvol_start_deep_copy` and `bdev_lvol_check_deep_copy` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -388,6 +388,10 @@ These RPCs use the new API `spdk_lvol_shallow_copy()`.
 Added `bdev_lvol_set_parent` and `bdev_lvol_set_parent_bdev` RPC to change the parent of an existing lvol
 with the use of the new APIs `spdk_lvol_set_parent()` and `spdk_lvol_set_external_parent()`.
 
+Added `bdev_lvol_start_deep_copy` RPC to start a deep copy of an lvol over a given bdev and
+`bdev_lvol_check_deep_copy` RPC to get the status of the operation.
+These RPCs use the new API `spdk_lvol_deep_copy()`.
+
 ### nvme
 
 Added `spdk_nvme_ctrlr_get_max_sges()` API to retrieve maximum number of SGEs per request
@@ -479,6 +483,9 @@ like rebuild.
 
 Added `spdk_bs_grow_live()` and `spdk_bdev_update_bs_blockcnt()` API that can be used to
 increase size of blobstore filling the underlying device without first closing the blobstore.
+
+Added new API `spdk_bs_blob_deep_copy` to make a deep copy from a blob to a blobstore device. Only clusters
+allocated to the blob or blob's ancestors will be written on the device.
 
 ### env
 

--- a/doc/blob.md
+++ b/doc/blob.md
@@ -446,6 +446,13 @@ than blob's size and blob store's block size must be an integer multiple of devi
 This functionality can be used to recreate the entire snapshot stack of a blob into a different blob
 store.
 
+#### Deep Copy {#blob_deep_copy}
+
+A read only blob can be copied over a blob store device in a way that only clusters
+allocated to the blob or blob's ancestors will be written on the device. This device must have a size equal or greater
+than blob's size and blob store's block size must be an integer multiple of device's block size.
+This functionality can be used to make a full copy of a blob into a different blob on the same or different blobstore.
+
 #### Change the parent of a blob {#blob_reparent}
 
 We can change the parent of a thin provisioned blob, making the blob a clone of a snapshot of the

--- a/doc/jsonrpc.md
+++ b/doc/jsonrpc.md
@@ -504,6 +504,7 @@ Example response:
     "bdev_lvol_start_range_shallow_copy",
     "bdev_lvol_check_shallow_copy",
     "bdev_lvol_start_deep_copy",
+    "bdev_lvol_check_deep_copy",
     "bdev_lvol_set_parent",
     "bdev_lvol_set_parent_bdev",
     "bdev_lvol_get_fragmap",
@@ -11375,6 +11376,55 @@ Example response:
   "id": 1,
   "result": {
     "operation_id": 7
+  }
+}
+~~~
+
+### bdev_lvol_check_deep_copy {#rpc_bdev_lvol_check_deep_copy}
+
+Get deep copy status.
+
+#### Result
+
+Get info about the deep copy operation identified by operation id.
+It reports operation's status, which can be `in progress`, `complete` or `error`,
+the actual number of processed clusters, the total number of clusters to process and,
+in case of error, a description.
+Once the operation is ended and the result has been retrieved, the
+operation is removed from the internal list of ended operation, so its
+result cannot be accessed anymore.
+
+#### Parameters
+
+Name                    | Optional | Type        | Description
+----------------------- | -------- | ----------- | -----------
+operation_id            | Required | number      | operation identifier
+
+#### Example
+
+Example request:
+
+~~~json
+{
+  "jsonrpc": "2.0",
+  "method": "bdev_lvol_check_deep_copy",
+  "id": 1,
+  "params": {
+    "operation_id": 7
+  }
+}
+~~~
+
+Example response:
+
+~~~json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "state": "in progress",
+    "processed_clusters": 2,
+    "total_clusters": 4
   }
 }
 ~~~

--- a/doc/jsonrpc.md
+++ b/doc/jsonrpc.md
@@ -503,6 +503,7 @@ Example response:
     "bdev_lvol_start_shallow_copy",
     "bdev_lvol_start_range_shallow_copy",
     "bdev_lvol_check_shallow_copy",
+    "bdev_lvol_start_deep_copy",
     "bdev_lvol_set_parent",
     "bdev_lvol_set_parent_bdev",
     "bdev_lvol_get_fragmap",
@@ -11325,6 +11326,55 @@ Example response:
     "state": "in progress",
     "copied_clusters": 2,
     "total_clusters": 4
+  }
+}
+~~~
+
+### bdev_lvol_start_deep_copy {#rpc_bdev_lvol_start_deep_copy}
+
+Start a deep copy of a lvol over a given bdev. Only clusters allocated to the lvol or the lvol's ancestors will be written on the bdev.
+Must have:
+
+* lvol read only
+* lvol size less or equal than bdev size
+* lvstore block size an even multiple of bdev block size
+
+#### Result
+
+This RPC starts the operation and return an identifier that can be used to query the status of the operation
+with the RPC @ref rpc_bdev_lvol_check_deep_copy.
+
+#### Parameters
+
+Name                    | Optional | Type        | Description
+----------------------- | -------- | ----------- | -----------
+src_lvol_name           | Required | string      | UUID or alias of lvol to create a copy from
+dst_bdev_name           | Required | string      | Name of the bdev that acts as destination for the copy
+
+#### Example
+
+Example request:
+
+~~~json
+{
+  "jsonrpc": "2.0",
+  "method": "bdev_lvol_start_deep_copy",
+  "id": 1,
+  "params": {
+    "src_lvol_name": "8a47421a-20cf-444f-845c-d97ad0b0bd8e",
+    "dst_bdev_name": "Nvme1n1"
+  }
+}
+~~~
+
+Example response:
+
+~~~json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "operation_id": 7
   }
 }
 ~~~

--- a/doc/lvol.md
+++ b/doc/lvol.md
@@ -212,6 +212,16 @@ bdev_lvol_check_shallow_copy [-h] operation_id
     Get shallow copy status
     optional arguments:
     -h, --help  show help
+bdev_lvol_start_deep_copy [-h] src_lvol_name dst_bdev_name
+    Make a deep copy of lvol over a given bdev
+    This RPC starts the operation and returns an identifier that can be used to query the status
+    of the operation with the RPC bdev_lvol_check_deep_copy.
+    optional arguments:
+    -h, --help  show help
+bdev_lvol_check_deep_copy [-h] operation_id
+    Get deep copy status
+    optional arguments:
+    -h, --help  show help
 bdev_lvol_set_parent [-h] lvol_name snapshot_name
     Set the parent snapshot of a lvol
     optional arguments:

--- a/include/spdk/blob.h
+++ b/include/spdk/blob.h
@@ -160,6 +160,15 @@ typedef void (*spdk_blob_shallow_copy_status)(uint64_t copied_clusters, uint64_t
 		void *cb_arg);
 
 /**
+ * Blob deep copy status callback.
+ *
+ * \param processed_clusters Number of processed clusters by the deep copy operation
+ * \param cb_arg Callback argument.
+ */
+typedef void (*spdk_blob_deep_copy_status)(uint64_t processed_clusters,
+		void *cb_arg);
+
+/**
  * Snapshot checksum stop callback.
  *
  * This callback inform the snapshot checksum compute operation if it can proceed or if
@@ -883,6 +892,29 @@ int spdk_bs_blob_range_shallow_copy(struct spdk_blob_store *bs, struct spdk_io_c
 				    struct spdk_bs_dev *ext_dev,
 				    spdk_blob_shallow_copy_status status_cb_fn, void *status_cb_arg,
 				    spdk_blob_op_complete cb_fn, void *cb_arg);
+/**
+ * Perform a deep copy of a blob to a blobstore device.
+ *
+ * This makes a deep copy from a blob to a blobstore device.
+ * Clusters allocated to the blob or its parents will be written on the device.
+ * Blob must be read only and blob size must be less or equal than device size.
+ * Blobstore block size must be a multiple of device block size.
+
+ * \param bs Blobstore
+ * \param channel IO channel used to copy the blob.
+ * \param blobid The id of the blob.
+ * \param ext_dev The device to copy on
+ * \param status_cb_fn Called repeatedly during operation with status updates
+ * \param status_cb_arg Argument passed to function status_cb_fn.
+ * \param cb_fn Called when the operation is complete.
+ * \param cb_arg Argument passed to function cb_fn.
+ *
+ * \return 0 if operation starts correctly, negative errno on failure.
+ */
+int spdk_bs_blob_deep_copy(struct spdk_blob_store *bs, struct spdk_io_channel *channel,
+			   spdk_blob_id blobid, struct spdk_bs_dev *ext_dev,
+			   spdk_blob_deep_copy_status status_cb_fn, void *status_cb_arg,
+			   spdk_blob_op_complete cb_fn, void *cb_arg);
 
 /**
  * Set a snapshot as the parent of a blob

--- a/include/spdk/lvol.h
+++ b/include/spdk/lvol.h
@@ -473,6 +473,25 @@ int spdk_lvol_shallow_copy(struct spdk_lvol *lvol, struct spdk_bs_dev *ext_dev,
 			   spdk_lvol_op_complete cb_fn, void *cb_arg);
 
 /**
+ * Make a deep copy of lvol on given bs_dev.
+ *
+ * Lvol must be read only and lvol size must be less or equal than bs_dev size.
+ *
+ * \param lvol Handle to lvol
+ * \param ext_dev The bs_dev to copy on. This is created on the given bdev by using
+ * spdk_bdev_create_bs_dev_ext() beforehand
+ * \param status_cb_fn Called repeatedly during operation with status updates
+ * \param status_cb_arg Argument passed to function status_cb_fn.
+ * \param cb_fn Completion callback
+ * \param cb_arg Completion callback custom arguments
+ *
+ * \return 0 if operation starts correctly, negative errno on failure.
+ */
+int spdk_lvol_deep_copy(struct spdk_lvol *lvol, struct spdk_bs_dev *ext_dev,
+			spdk_blob_deep_copy_status status_cb_fn, void *status_cb_arg,
+			spdk_lvol_op_complete cb_fn, void *cb_arg);
+
+/**
  * Make a ranged shallow copy of lvol on given bs_dev.
  *
  * Lvol must be read only, and the cluster range must fit into lvol and device size.

--- a/lib/blob/blobstore.c
+++ b/lib/blob/blobstore.c
@@ -48,6 +48,7 @@ static void blob_freeze_io(struct spdk_blob *blob, spdk_blob_op_complete cb_fn, 
 
 static void bs_shallow_copy_cluster_find_next(void *cb_arg);
 static void bs_range_shallow_copy_cluster_handle_next(void *cb_arg);
+static void bs_deep_copy_cluster_find_next(void *cb_arg);
 static void bs_snapshot_checksum_cluster_find_next(void *cb_arg);
 
 static void blob_sync_md(struct spdk_blob *blob, spdk_blob_op_complete cb_fn, void *cb_arg);
@@ -7854,7 +7855,7 @@ spdk_bs_blob_range_shallow_copy(struct spdk_blob_store *bs, struct spdk_io_chann
 	if (!ext_channel) {
 		spdk_free(ctx->read_buff);
 		free(ctx);
-		return -ENOMEM;
+		return -1;
 	}
 	ctx->ext_dev = ext_dev;
 	ctx->ext_channel = ext_channel;
@@ -7864,6 +7865,257 @@ spdk_bs_blob_range_shallow_copy(struct spdk_blob_store *bs, struct spdk_io_chann
 	return 0;
 }
 /* END spdk_bs_blob_range_shallow_copy */
+
+/* START spdk_bs_blob_deep_copy */
+struct deep_copy_ctx {
+	struct spdk_bs_cpl cpl;
+	int bserrno;
+
+	/* Blob source for copy */
+	struct spdk_blob_store *bs;
+	spdk_blob_id blobid;
+	struct spdk_blob *blob;
+	struct spdk_io_channel *blob_channel;
+
+	/* Destination device for copy */
+	struct spdk_bs_dev *ext_dev;
+	struct spdk_io_channel *ext_channel;
+
+	/* Current cluster for copy operation */
+	uint64_t cluster;
+
+	/* Buffer for blob reading */
+	uint8_t *read_buff;
+
+	/* Struct for external device writing */
+	struct spdk_bs_dev_cb_args ext_args;
+
+	/* Status callback for updates about the ongoing operation */
+	spdk_blob_deep_copy_status status_cb;
+
+	/* Argument passed to function status_cb */
+	void *status_cb_arg;
+};
+
+static void
+bs_deep_copy_cleanup_finish(void *cb_arg, int bserrno)
+{
+	struct deep_copy_ctx *ctx = cb_arg;
+	struct spdk_bs_cpl *cpl = &ctx->cpl;
+
+	if (bserrno != 0) {
+		SPDK_ERRLOG("blob 0x%" PRIx64 " deep copy, cleanup error %d\n", ctx->blob->id, bserrno);
+		ctx->bserrno = bserrno;
+	}
+
+	ctx->ext_dev->destroy_channel(ctx->ext_dev, ctx->ext_channel);
+	spdk_free(ctx->read_buff);
+
+	cpl->u.blob_basic.cb_fn(cpl->u.blob_basic.cb_arg, ctx->bserrno);
+
+	free(ctx);
+}
+
+static void
+bs_deep_copy_bdev_write_cpl(struct spdk_io_channel *channel, void *cb_arg, int bserrno)
+{
+	struct deep_copy_ctx *ctx = cb_arg;
+	struct spdk_blob *_blob = ctx->blob;
+
+	if (bserrno != 0) {
+		SPDK_ERRLOG("blob 0x%" PRIx64 " deep copy, ext dev write error %d\n", ctx->blob->id, bserrno);
+		ctx->bserrno = bserrno;
+		_blob->locked_operation_in_progress = false;
+		spdk_blob_close(_blob, bs_deep_copy_cleanup_finish, ctx);
+		return;
+	}
+
+	ctx->cluster++;
+
+	if (ctx->status_cb) {
+		ctx->status_cb(ctx->cluster, ctx->status_cb_arg);
+	}
+
+	bs_deep_copy_cluster_find_next(ctx);
+}
+
+static void
+bs_deep_copy_blob_read_cpl(void *cb_arg, int bserrno)
+{
+	struct deep_copy_ctx *ctx = cb_arg;
+	struct spdk_bs_dev *ext_dev = ctx->ext_dev;
+	struct spdk_blob *_blob = ctx->blob;
+
+	if (bserrno != 0) {
+		SPDK_ERRLOG("blob 0x%" PRIx64 " deep copy, blob read error %d\n", ctx->blob->id, bserrno);
+		ctx->bserrno = bserrno;
+		_blob->locked_operation_in_progress = false;
+		spdk_blob_close(_blob, bs_deep_copy_cleanup_finish, ctx);
+		return;
+	}
+
+	ctx->ext_args.channel = ctx->ext_channel;
+	ctx->ext_args.cb_fn = bs_deep_copy_bdev_write_cpl;
+	ctx->ext_args.cb_arg = ctx;
+
+	ext_dev->write(ext_dev, ctx->ext_channel, ctx->read_buff,
+		       bs_cluster_to_lba(_blob->bs, ctx->cluster),
+		       bs_dev_byte_to_lba(_blob->bs->dev, _blob->bs->cluster_sz),
+		       &ctx->ext_args);
+}
+
+
+static void
+bs_deep_copy_cluster_find_next(void *cb_arg)
+{
+	struct deep_copy_ctx *ctx = cb_arg;
+	struct spdk_blob *_blob = ctx->blob;
+	bool is_valid_range;
+	bool is_zeroes;
+
+	while (ctx->cluster < _blob->active.num_clusters) {
+		if (_blob->active.clusters[ctx->cluster] != 0) {
+			// The cluster is allocated in the current blob
+			break;
+		}
+
+		/* Check if the cluster valid for
+		 * the backing dev. For zeroes backing dev, it'll be always valid.
+		 *
+		 * For other backing dev e.g. a snapshot, it could be invalid if
+		 * the blob has been resized after snapshot was taken. Note that
+		 * in this case, we might unnecessarily copy cluster which is in
+		 * the expanded offset but not allocated in _blob or its ancestors.
+		 * We consider this a conner case.
+		 */
+		is_valid_range = _blob->back_bs_dev->is_range_valid(_blob->back_bs_dev,
+				 bs_io_unit_to_back_dev_lba(_blob, bs_cluster_to_lba(_blob->bs, ctx->cluster)),
+				 bs_dev_byte_to_lba(_blob->back_bs_dev, _blob->bs->cluster_sz));
+		is_zeroes = is_valid_range && _blob->back_bs_dev->is_zeroes(_blob->back_bs_dev,
+				bs_io_unit_to_back_dev_lba(_blob, bs_cluster_to_lba(_blob->bs, ctx->cluster)),
+				bs_dev_byte_to_lba(_blob->back_bs_dev, _blob->bs->cluster_sz));
+		if (_blob->parent_id != SPDK_BLOBID_INVALID && !is_zeroes) {
+			// The cluster is allocated in one of the ancestors of the blob
+			break;
+		}
+
+		ctx->cluster++;
+	}
+
+	if (ctx->cluster < _blob->active.num_clusters) {
+		blob_request_submit_op_single(ctx->blob_channel, _blob, ctx->read_buff,
+					      bs_cluster_to_lba(_blob->bs, ctx->cluster),
+					      bs_dev_byte_to_lba(_blob->bs->dev, _blob->bs->cluster_sz),
+					      bs_deep_copy_blob_read_cpl, ctx, SPDK_BLOB_READ);
+	} else {
+		if (ctx->status_cb) {
+			ctx->status_cb(_blob->active.num_clusters, ctx->status_cb_arg);
+		}
+		_blob->locked_operation_in_progress = false;
+		spdk_blob_close(_blob, bs_deep_copy_cleanup_finish, ctx);
+	}
+}
+
+static void
+bs_deep_copy_blob_open_cpl(void *cb_arg, struct spdk_blob *_blob, int bserrno)
+{
+	struct deep_copy_ctx *ctx = cb_arg;
+	struct spdk_bs_dev *ext_dev = ctx->ext_dev;
+	uint32_t blob_block_size;
+	uint64_t blob_total_size;
+
+	if (bserrno != 0) {
+		SPDK_ERRLOG("Deep copy blob open error %d\n", bserrno);
+		ctx->bserrno = bserrno;
+		bs_deep_copy_cleanup_finish(ctx, 0);
+		return;
+	}
+
+	if (!spdk_blob_is_read_only(_blob)) {
+		SPDK_ERRLOG("blob 0x%" PRIx64 " deep copy, blob must be read only\n", _blob->id);
+		ctx->bserrno = -EPERM;
+		spdk_blob_close(_blob, bs_deep_copy_cleanup_finish, ctx);
+		return;
+	}
+
+	blob_block_size = _blob->bs->dev->blocklen;
+	blob_total_size = spdk_blob_get_num_clusters(_blob) * spdk_bs_get_cluster_size(_blob->bs);
+
+	if (blob_total_size > ext_dev->blockcnt * ext_dev->blocklen) {
+		SPDK_ERRLOG("blob 0x%" PRIx64 " deep copy, external device must have at least blob size\n",
+			    _blob->id);
+		ctx->bserrno = -EINVAL;
+		spdk_blob_close(_blob, bs_deep_copy_cleanup_finish, ctx);
+		return;
+	}
+
+	if (blob_block_size % ext_dev->blocklen != 0) {
+		SPDK_ERRLOG("blob 0x%" PRIx64 " deep copy, external device block size is not compatible with \
+blobstore block size\n", _blob->id);
+		ctx->bserrno = -EINVAL;
+		spdk_blob_close(_blob, bs_deep_copy_cleanup_finish, ctx);
+		return;
+	}
+
+	ctx->blob = _blob;
+
+	if (_blob->locked_operation_in_progress) {
+		SPDK_DEBUGLOG(blob, "blob 0x%" PRIx64 " deep copy - another operation in progress\n", _blob->id);
+		ctx->bserrno = -EBUSY;
+		spdk_blob_close(_blob, bs_deep_copy_cleanup_finish, ctx);
+		return;
+	}
+
+	_blob->locked_operation_in_progress = true;
+
+	ctx->cluster = 0;
+	bs_deep_copy_cluster_find_next(ctx);
+}
+
+int
+spdk_bs_blob_deep_copy(struct spdk_blob_store *bs, struct spdk_io_channel *channel,
+		       spdk_blob_id blobid, struct spdk_bs_dev *ext_dev,
+		       spdk_blob_deep_copy_status status_cb_fn, void *status_cb_arg,
+		       spdk_blob_op_complete cb_fn, void *cb_arg)
+{
+	struct deep_copy_ctx *ctx;
+	struct spdk_io_channel *ext_channel;
+
+	ctx = calloc(1, sizeof(*ctx));
+	if (!ctx) {
+		return -ENOMEM;
+	}
+
+	ctx->bs = bs;
+	ctx->blobid = blobid;
+	ctx->cpl.type = SPDK_BS_CPL_TYPE_BLOB_BASIC;
+	ctx->cpl.u.bs_basic.cb_fn = cb_fn;
+	ctx->cpl.u.bs_basic.cb_arg = cb_arg;
+	ctx->bserrno = 0;
+	ctx->blob_channel = channel;
+	ctx->status_cb = status_cb_fn;
+	ctx->status_cb_arg = status_cb_arg;
+	ctx->read_buff = spdk_malloc(bs->cluster_sz, bs->dev->blocklen, NULL,
+				     SPDK_ENV_LCORE_ID_ANY, SPDK_MALLOC_DMA);
+	if (!ctx->read_buff) {
+		free(ctx);
+		return -ENOMEM;
+	}
+
+	ext_channel = ext_dev->create_channel(ext_dev);
+	if (!ext_channel) {
+		spdk_free(ctx->read_buff);
+		free(ctx);
+		return -ENOMEM;
+	}
+	ctx->ext_dev = ext_dev;
+	ctx->ext_channel = ext_channel;
+
+	spdk_bs_open_blob(ctx->bs, ctx->blobid, bs_deep_copy_blob_open_cpl, ctx);
+
+	return 0;
+}
+/* END spdk_bs_blob_shallow_copy */
 
 /* START spdk_bs_blob_set_parent */
 

--- a/lib/blob/spdk_blob.map
+++ b/lib/blob/spdk_blob.map
@@ -41,6 +41,7 @@
 	spdk_bs_blob_decouple_parent;
 	spdk_bs_blob_detach_parent;
 	spdk_bs_blob_shallow_copy;
+	spdk_bs_blob_deep_copy;
 	spdk_bs_blob_range_shallow_copy;
 	spdk_bs_blob_set_parent;
 	spdk_bs_blob_set_external_parent;

--- a/lib/lvol/lvol.c
+++ b/lib/lvol/lvol.c
@@ -1549,7 +1549,7 @@ spdk_lvol_create_snapshot_with_xattrs(struct spdk_lvol *origlvol, const char *sn
 		return;
 	}
 
-	/* 
+	/*
 	 * Elements inside xattrs_external are as the following example:
 	 * [xattr1_name, xattr1_value, xattr2_name, xattr2_value, ...]
 	 * So xattr names are in even position.
@@ -2731,6 +2731,75 @@ spdk_lvol_range_shallow_copy(struct spdk_lvol *lvol, uint64_t *clusters_indexes,
 
 	if (rc < 0) {
 		SPDK_ERRLOG("Could not make a range shallow copy of lvol %s\n", lvol->unique_id);
+		spdk_bs_free_io_channel(req->channel);
+		free(req);
+	}
+
+	return rc;
+}
+
+static void
+lvol_deep_copy_cb(void *cb_arg, int lvolerrno)
+{
+	struct spdk_lvol_copy_req *req = cb_arg;
+	struct spdk_lvol *lvol = req->lvol;
+
+	spdk_bs_free_io_channel(req->channel);
+
+	if (lvolerrno < 0) {
+		SPDK_ERRLOG("Could not make a deep copy of lvol %s, error %d\n", lvol->unique_id, lvolerrno);
+	}
+
+	req->cb_fn(req->cb_arg, lvolerrno);
+	free(req);
+}
+
+int
+spdk_lvol_deep_copy(struct spdk_lvol *lvol, struct spdk_bs_dev *ext_dev,
+		    spdk_blob_deep_copy_status status_cb_fn, void *status_cb_arg,
+		    spdk_lvol_op_complete cb_fn, void *cb_arg)
+{
+	struct spdk_lvol_copy_req *req;
+	spdk_blob_id blob_id;
+	int rc;
+
+	assert(cb_fn != NULL);
+
+	if (lvol == NULL) {
+		SPDK_ERRLOG("lvol must not be NULL\n");
+		return -EINVAL;
+	}
+
+	assert(lvol->lvol_store->thread == spdk_get_thread());
+
+	if (ext_dev == NULL) {
+		SPDK_ERRLOG("lvol %s deep copy, ext_dev must not be NULL\n", lvol->unique_id);
+		return -EINVAL;
+	}
+
+	req = calloc(1, sizeof(*req));
+	if (!req) {
+		SPDK_ERRLOG("lvol %s deep copy, cannot alloc memory for lvol request\n", lvol->unique_id);
+		return -ENOMEM;
+	}
+
+	req->lvol = lvol;
+	req->cb_fn = cb_fn;
+	req->cb_arg = cb_arg;
+	req->channel = spdk_bs_alloc_io_channel(lvol->lvol_store->blobstore);
+	if (req->channel == NULL) {
+		SPDK_ERRLOG("lvol %s deep copy, cannot alloc io channel for lvol request\n", lvol->unique_id);
+		free(req);
+		return -ENOMEM;
+	}
+
+	blob_id = spdk_blob_get_id(lvol->blob);
+
+	rc = spdk_bs_blob_deep_copy(lvol->lvol_store->blobstore, req->channel, blob_id, ext_dev,
+				    status_cb_fn, status_cb_arg, lvol_deep_copy_cb, req);
+
+	if (rc < 0) {
+		SPDK_ERRLOG("Could not make a deep copy of lvol %s\n", lvol->unique_id);
 		spdk_bs_free_io_channel(req->channel);
 		free(req);
 	}

--- a/lib/lvol/spdk_lvol.map
+++ b/lib/lvol/spdk_lvol.map
@@ -31,6 +31,7 @@
 	spdk_lvol_get_by_names;
 	spdk_lvol_is_degraded;
 	spdk_lvol_shallow_copy;
+	spdk_lvol_deep_copy;
 	spdk_lvol_range_shallow_copy;
 	spdk_lvol_set_parent;
 	spdk_lvol_set_external_parent;

--- a/module/bdev/lvol/vbdev_lvol.c
+++ b/module/bdev/lvol/vbdev_lvol.c
@@ -2389,6 +2389,87 @@ vbdev_lvol_range_shallow_copy(struct spdk_lvol *lvol, const char *bdev_name,
 	return rc;
 }
 
+static void
+_vbdev_lvol_deep_copy_base_bdev_event_cb(enum spdk_bdev_event_type type, struct spdk_bdev *bdev,
+		void *event_ctx)
+{
+}
+
+static void
+_vbdev_lvol_deep_copy_cb(void *cb_arg, int lvolerrno)
+{
+	struct spdk_lvol_copy_req *req = cb_arg;
+	struct spdk_lvol *lvol = req->lvol;
+
+	if (lvolerrno != 0) {
+		SPDK_ERRLOG("Could not make a deep copy of lvol %s due to error: %d\n",
+			    lvol->name, lvolerrno);
+	}
+
+	req->ext_dev->destroy(req->ext_dev);
+	req->cb_fn(req->cb_arg, lvolerrno);
+	free(req);
+}
+
+int
+vbdev_lvol_deep_copy(struct spdk_lvol *lvol, const char *bdev_name,
+		     spdk_blob_deep_copy_status status_cb_fn, void *status_cb_arg,
+		     spdk_lvol_op_complete cb_fn, void *cb_arg)
+{
+	struct spdk_bs_dev *ext_dev;
+	struct spdk_lvol_copy_req *req;
+	int rc;
+
+	if (lvol == NULL) {
+		SPDK_ERRLOG("lvol must not be NULL\n");
+		return -EINVAL;
+	}
+
+	if (bdev_name == NULL) {
+		SPDK_ERRLOG("lvol %s, bdev name must not be NULL\n", lvol->name);
+		return -EINVAL;
+	}
+
+	assert(lvol->bdev != NULL);
+
+	req = calloc(1, sizeof(*req));
+	if (req == NULL) {
+		SPDK_ERRLOG("lvol %s, cannot alloc memory for lvol copy request\n", lvol->name);
+		return -ENOMEM;
+	}
+
+	rc = spdk_bdev_create_bs_dev_ext(bdev_name, _vbdev_lvol_deep_copy_base_bdev_event_cb,
+					 NULL, &ext_dev);
+	if (rc < 0) {
+		SPDK_ERRLOG("lvol %s, cannot create blobstore device from bdev %s\n", lvol->name, bdev_name);
+		free(req);
+		return rc;
+	}
+
+	rc = spdk_bs_bdev_claim(ext_dev, &g_lvol_if);
+	if (rc != 0) {
+		SPDK_ERRLOG("lvol %s, unable to claim bdev %s, error %d\n", lvol->name, bdev_name, rc);
+		ext_dev->destroy(ext_dev);
+		free(req);
+		return rc;
+	}
+
+	req->cb_fn = cb_fn;
+	req->cb_arg = cb_arg;
+	req->lvol = lvol;
+	req->ext_dev = ext_dev;
+
+	rc = spdk_lvol_deep_copy(lvol, ext_dev, status_cb_fn, status_cb_arg, _vbdev_lvol_deep_copy_cb,
+				 req);
+
+	if (rc < 0) {
+		ext_dev->destroy(ext_dev);
+		free(req);
+	}
+
+	return rc;
+}
+
 void
 vbdev_lvol_set_external_parent(struct spdk_lvol *lvol, const char *esnap_name,
 			       spdk_lvol_op_complete cb_fn, void *cb_arg)

--- a/module/bdev/lvol/vbdev_lvol.h
+++ b/module/bdev/lvol/vbdev_lvol.h
@@ -158,6 +158,22 @@ int vbdev_lvol_shallow_copy(struct spdk_lvol *lvol, const char *bdev_name,
 			    spdk_lvol_op_complete cb_fn, void *cb_arg);
 
 /**
+ * \brief Make a deep copy of lvol over a bdev
+ *
+ * \param lvol Handle to lvol
+ * \param bdev_name Name of the bdev to copy on
+ * \param status_cb_fn Called repeatedly during operation with status updates
+ * \param status_cb_arg Argument passed to function status_cb_fn.
+ * \param cb_fn Completion callback
+ * \param cb_arg Completion callback custom arguments
+ *
+ * \return 0 if operation starts correctly, negative errno on failure.
+ */
+int vbdev_lvol_deep_copy(struct spdk_lvol *lvol, const char *bdev_name,
+			 spdk_blob_deep_copy_status status_cb_fn, void *status_cb_arg,
+			 spdk_lvol_op_complete cb_fn, void *cb_arg);
+
+/**
  * \brief Make a range shallow copy of lvol over a bdev
  *
  * \param lvol Handle to lvol

--- a/module/bdev/lvol/vbdev_lvol_rpc.c
+++ b/module/bdev/lvol/vbdev_lvol_rpc.c
@@ -34,6 +34,22 @@ static uint32_t g_shallow_copy_count = 0;
 static LIST_HEAD(, rpc_shallow_copy_status) g_shallow_copy_status_list = LIST_HEAD_INITIALIZER(
 			&g_shallow_copy_status_list);
 
+struct rpc_deep_copy_status {
+	uint32_t				operation_id;
+	/*
+	 * 0 means ongoing or successfully completed operation
+	 * a negative value is the -errno of an aborted operation
+	 */
+	int					result;
+	uint64_t				processed_clusters;
+	uint64_t				total_clusters;
+	LIST_ENTRY(rpc_deep_copy_status)	link;
+};
+
+static uint32_t g_deep_copy_count = 0;
+static LIST_HEAD(, rpc_deep_copy_status) g_deep_copy_status_list = LIST_HEAD_INITIALIZER(
+			&g_deep_copy_status_list);
+
 enum snapshot_checksum_status {
 	SNAPSHOT_CHECKSUM_RUNNING,
 	SNAPSHOT_CHECKSUM_STOPPING,
@@ -1922,6 +1938,132 @@ cleanup:
 }
 
 SPDK_RPC_REGISTER("bdev_lvol_check_shallow_copy", rpc_bdev_lvol_check_shallow_copy,
+		  SPDK_RPC_RUNTIME)
+
+struct rpc_bdev_lvol_deep_copy {
+	char *src_lvol_name;
+	char *dst_bdev_name;
+};
+
+struct rpc_bdev_lvol_deep_copy_ctx {
+	struct spdk_jsonrpc_request *request;
+	struct rpc_deep_copy_status *status;
+};
+
+static void
+free_rpc_bdev_lvol_deep_copy(struct rpc_bdev_lvol_deep_copy *req)
+{
+	free(req->src_lvol_name);
+	free(req->dst_bdev_name);
+}
+
+static const struct spdk_json_object_decoder rpc_bdev_lvol_deep_copy_decoders[] = {
+	{"src_lvol_name", offsetof(struct rpc_bdev_lvol_deep_copy, src_lvol_name), spdk_json_decode_string},
+	{"dst_bdev_name", offsetof(struct rpc_bdev_lvol_deep_copy, dst_bdev_name), spdk_json_decode_string},
+};
+
+static void
+rpc_bdev_lvol_deep_copy_cb(void *cb_arg, int lvolerrno)
+{
+	struct rpc_bdev_lvol_deep_copy_ctx *ctx = cb_arg;
+
+	ctx->status->result = lvolerrno;
+	free(ctx);
+}
+
+static void
+rpc_bdev_lvol_deep_copy_status_cb(uint64_t processed_clusters,
+				  void *cb_arg)
+{
+	struct rpc_deep_copy_status *status = cb_arg;
+
+	status->processed_clusters = processed_clusters;
+}
+
+
+static void
+rpc_bdev_lvol_start_deep_copy(struct spdk_jsonrpc_request *request,
+			      const struct spdk_json_val *params)
+{
+	struct rpc_bdev_lvol_deep_copy req = {};
+	struct rpc_bdev_lvol_deep_copy_ctx *ctx;
+	struct spdk_lvol *src_lvol;
+	struct spdk_bdev *src_lvol_bdev;
+	struct rpc_deep_copy_status *status;
+	struct spdk_json_write_ctx *w;
+	int rc;
+
+	SPDK_INFOLOG(lvol_rpc, "Deep copying lvol\n");
+
+	if (spdk_json_decode_object(params, rpc_bdev_lvol_deep_copy_decoders,
+				    SPDK_COUNTOF(rpc_bdev_lvol_deep_copy_decoders),
+				    &req)) {
+		SPDK_INFOLOG(lvol_rpc, "spdk_json_decode_object failed\n");
+		spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_INTERNAL_ERROR,
+						 "spdk_json_decode_object failed");
+		goto cleanup;
+	}
+
+	src_lvol_bdev = spdk_bdev_get_by_name(req.src_lvol_name);
+	if (src_lvol_bdev == NULL) {
+		SPDK_ERRLOG("lvol bdev '%s' does not exist\n", req.src_lvol_name);
+		spdk_jsonrpc_send_error_response(request, -ENODEV, spdk_strerror(ENODEV));
+		goto cleanup;
+	}
+
+	src_lvol = vbdev_lvol_get_from_bdev(src_lvol_bdev);
+	if (src_lvol == NULL) {
+		SPDK_ERRLOG("lvol does not exist\n");
+		spdk_jsonrpc_send_error_response(request, -ENODEV, spdk_strerror(ENODEV));
+		goto cleanup;
+	}
+
+	status = calloc(1, sizeof(*status));
+	if (status == NULL) {
+		SPDK_ERRLOG("Cannot allocate status entry for deep copy of '%s'\n", req.src_lvol_name);
+		spdk_jsonrpc_send_error_response(request, -ENOMEM, spdk_strerror(ENOMEM));
+		goto cleanup;
+	}
+
+	status->operation_id = ++g_deep_copy_count;
+	status->total_clusters = spdk_blob_get_num_clusters(src_lvol->blob);
+
+	ctx = calloc(1, sizeof(*ctx));
+	if (ctx == NULL) {
+		SPDK_ERRLOG("Cannot allocate context for deep copy of '%s'\n", req.src_lvol_name);
+		spdk_jsonrpc_send_error_response(request, -ENOMEM, spdk_strerror(ENOMEM));
+		free(status);
+		goto cleanup;
+	}
+	ctx->request = request;
+	ctx->status = status;
+
+	LIST_INSERT_HEAD(&g_deep_copy_status_list, status, link);
+	rc = vbdev_lvol_deep_copy(src_lvol, req.dst_bdev_name,
+				  rpc_bdev_lvol_deep_copy_status_cb, status,
+				  rpc_bdev_lvol_deep_copy_cb, ctx);
+
+	if (rc < 0) {
+		spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_INVALID_PARAMS,
+						 spdk_strerror(-rc));
+		LIST_REMOVE(status, link);
+		free(ctx);
+		free(status);
+	} else {
+		w = spdk_jsonrpc_begin_result(request);
+
+		spdk_json_write_object_begin(w);
+		spdk_json_write_named_uint32(w, "operation_id", status->operation_id);
+		spdk_json_write_object_end(w);
+
+		spdk_jsonrpc_end_result(request, w);
+	}
+
+cleanup:
+	free_rpc_bdev_lvol_deep_copy(&req);
+}
+
+SPDK_RPC_REGISTER("bdev_lvol_start_deep_copy", rpc_bdev_lvol_start_deep_copy,
 		  SPDK_RPC_RUNTIME)
 
 struct rpc_bdev_lvol_set_parent {

--- a/module/bdev/lvol/vbdev_lvol_rpc.c
+++ b/module/bdev/lvol/vbdev_lvol_rpc.c
@@ -2066,6 +2066,88 @@ cleanup:
 SPDK_RPC_REGISTER("bdev_lvol_start_deep_copy", rpc_bdev_lvol_start_deep_copy,
 		  SPDK_RPC_RUNTIME)
 
+struct rpc_bdev_lvol_deep_copy_status {
+	char		*src_lvol_name;
+	uint32_t	operation_id;
+};
+
+static void
+free_rpc_bdev_lvol_deep_copy_status(struct rpc_bdev_lvol_deep_copy_status *req)
+{
+	free(req->src_lvol_name);
+}
+
+static const struct spdk_json_object_decoder rpc_bdev_lvol_deep_copy_status_decoders[] = {
+	{"operation_id", offsetof(struct rpc_bdev_lvol_deep_copy_status, operation_id), spdk_json_decode_uint32},
+};
+
+static void
+rpc_bdev_lvol_check_deep_copy(struct spdk_jsonrpc_request *request,
+			      const struct spdk_json_val *params)
+{
+	struct rpc_bdev_lvol_deep_copy_status req = {};
+	struct rpc_deep_copy_status *status;
+	struct spdk_json_write_ctx *w;
+	uint64_t processed_clusters, total_clusters;
+	int result;
+
+	SPDK_INFOLOG(lvol_rpc, "Deep copy check\n");
+
+	if (spdk_json_decode_object(params, rpc_bdev_lvol_deep_copy_status_decoders,
+				    SPDK_COUNTOF(rpc_bdev_lvol_deep_copy_status_decoders),
+				    &req)) {
+		SPDK_INFOLOG(lvol_rpc, "spdk_json_decode_object failed\n");
+		spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_INTERNAL_ERROR,
+						 "spdk_json_decode_object failed");
+		goto cleanup;
+	}
+
+	LIST_FOREACH(status, &g_deep_copy_status_list, link) {
+		if (status->operation_id == req.operation_id) {
+			break;
+		}
+	}
+
+	if (!status) {
+		SPDK_ERRLOG("operation id '%d' does not exist\n", req.operation_id);
+		spdk_jsonrpc_send_error_response(request, -ENODEV, spdk_strerror(ENODEV));
+		goto cleanup;
+	}
+
+	processed_clusters = status->processed_clusters;
+	total_clusters = status->total_clusters;
+	result = status->result;
+
+	w = spdk_jsonrpc_begin_result(request);
+
+	spdk_json_write_object_begin(w);
+
+	spdk_json_write_named_uint64(w, "processed_clusters", processed_clusters);
+	spdk_json_write_named_uint64(w, "total_clusters", total_clusters);
+	if (processed_clusters < total_clusters && result == 0) {
+		spdk_json_write_named_string(w, "state", "in progress");
+	} else if (processed_clusters == total_clusters && result == 0) {
+		spdk_json_write_named_string(w, "state", "complete");
+		LIST_REMOVE(status, link);
+		free(status);
+	} else {
+		spdk_json_write_named_string(w, "state", "error");
+		spdk_json_write_named_string(w, "error", spdk_strerror(-result));
+		LIST_REMOVE(status, link);
+		free(status);
+	}
+
+	spdk_json_write_object_end(w);
+
+	spdk_jsonrpc_end_result(request, w);
+
+cleanup:
+	free_rpc_bdev_lvol_deep_copy_status(&req);
+}
+
+SPDK_RPC_REGISTER("bdev_lvol_check_deep_copy", rpc_bdev_lvol_check_deep_copy,
+		  SPDK_RPC_RUNTIME)
+
 struct rpc_bdev_lvol_set_parent {
 	char *lvol_name;
 	char *parent_name;

--- a/python/spdk/rpc/lvol.py
+++ b/python/spdk/rpc/lvol.py
@@ -331,6 +331,17 @@ def bdev_lvol_start_deep_copy(client, src_lvol_name, dst_bdev_name):
     }
     return client.call('bdev_lvol_start_deep_copy', params)
 
+def bdev_lvol_check_deep_copy(client, operation_id):
+    """Get deep copy status
+
+    Args:
+        operation_id: operation identifier
+    """
+    params = {
+        'operation_id': operation_id
+    }
+    return client.call('bdev_lvol_check_deep_copy', params)
+
 def bdev_lvol_set_parent(client, lvol_name, parent_name):
     """Set the parent snapshot of a lvol
 

--- a/python/spdk/rpc/lvol.py
+++ b/python/spdk/rpc/lvol.py
@@ -317,6 +317,19 @@ def bdev_lvol_check_shallow_copy(client, operation_id):
     }
     return client.call('bdev_lvol_check_shallow_copy', params)
 
+def bdev_lvol_start_deep_copy(client, src_lvol_name, dst_bdev_name):
+    """Start a deep copy of a lvol over a given bdev. The status of the operation
+    can be obtained with bdev_lvol_check_deep_copy
+
+    Args:
+        src_lvol_name: name of lvol to create a copy from
+        bdev_name: name of the bdev that acts as destination for the copy
+    """
+    params = {
+        'src_lvol_name': src_lvol_name,
+        'dst_bdev_name': dst_bdev_name
+    }
+    return client.call('bdev_lvol_start_deep_copy', params)
 
 def bdev_lvol_set_parent(client, lvol_name, parent_name):
     """Set the parent snapshot of a lvol

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -2254,6 +2254,18 @@ Format: 'user:u1 secret:s1 muser:mu1 msecret:ms1,user:u2 secret:s2 muser:mu2 mse
     p.add_argument('operation_id', help='operation identifier', type=int)
     p.set_defaults(func=bdev_lvol_check_shallow_copy)
 
+    def bdev_lvol_start_deep_copy(args):
+        print_json(rpc.lvol.bdev_lvol_start_deep_copy(args.client,
+                                                         src_lvol_name=args.src_lvol_name,
+                                                         dst_bdev_name=args.dst_bdev_name))
+
+    p = subparsers.add_parser('bdev_lvol_start_deep_copy',
+                              help="""Start a deep copy of a lvol over a given bdev. The status of the operation
+    can be obtained with bdev_lvol_check_deep_copy""")
+    p.add_argument('src_lvol_name', help='source lvol name')
+    p.add_argument('dst_bdev_name', help='destination bdev name')
+    p.set_defaults(func=bdev_lvol_start_deep_copy)
+
     def bdev_lvol_set_parent(args):
         rpc.lvol.bdev_lvol_set_parent(args.client,
                                       lvol_name=args.lvol_name,

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -2266,6 +2266,14 @@ Format: 'user:u1 secret:s1 muser:mu1 msecret:ms1,user:u2 secret:s2 muser:mu2 mse
     p.add_argument('dst_bdev_name', help='destination bdev name')
     p.set_defaults(func=bdev_lvol_start_deep_copy)
 
+    def bdev_lvol_check_deep_copy(args):
+        print_json(rpc.lvol.bdev_lvol_check_deep_copy(args.client,
+                                                         operation_id=args.operation_id))
+
+    p = subparsers.add_parser('bdev_lvol_check_deep_copy', help='Get deep copy status')
+    p.add_argument('operation_id', help='operation identifier', type=int)
+    p.set_defaults(func=bdev_lvol_check_deep_copy)
+
     def bdev_lvol_set_parent(args):
         rpc.lvol.bdev_lvol_set_parent(args.client,
                                       lvol_name=args.lvol_name,

--- a/test/lvol/external_copy.sh
+++ b/test/lvol/external_copy.sh
@@ -167,6 +167,85 @@ function test_range_shallow_copy_compare() {
 	check_leftover_devices
 }
 
+function test_deep_copy_compare() {
+	# Create lvs
+	bs_malloc_name=$(rpc_cmd bdev_malloc_create 20 $MALLOC_BS)
+	lvs_uuid=$(rpc_cmd bdev_lvol_create_lvstore "$bs_malloc_name" lvs_test)
+
+	# Create lvol with 4 cluster
+	lvol_size=$((LVS_DEFAULT_CLUSTER_SIZE_MB * 4))
+	lvol_uuid=$(rpc_cmd bdev_lvol_create -u "$lvs_uuid" lvol_test "$lvol_size" -t)
+
+	# Fill second and fourth cluster of lvol
+	nbd_start_disks "$DEFAULT_RPC_ADDR" "$lvol_uuid" /dev/nbd0
+	dd if=/dev/urandom of=/dev/nbd0 oflag=direct bs="$LVS_DEFAULT_CLUSTER_SIZE" count=1 seek=1
+	dd if=/dev/urandom of=/dev/nbd0 oflag=direct bs="$LVS_DEFAULT_CLUSTER_SIZE" count=1 seek=3
+	nbd_stop_disks "$DEFAULT_RPC_ADDR" /dev/nbd0
+
+	# Create snapshots of lvol bdev
+	snapshot_uuid=$(rpc_cmd bdev_lvol_snapshot lvs_test/lvol_test lvol_snapshot)
+
+	# Fill first cluster of lvol
+	nbd_start_disks "$DEFAULT_RPC_ADDR" "$lvol_uuid" /dev/nbd0
+	dd if=/dev/urandom of=/dev/nbd0 oflag=direct bs="$LVS_DEFAULT_CLUSTER_SIZE" count=1
+	nbd_stop_disks "$DEFAULT_RPC_ADDR" /dev/nbd0
+
+	# Set lvol as read only to perform the copy
+	rpc_cmd bdev_lvol_set_read_only "$lvol_uuid"
+
+	# Create external bdev to make a deep copy of lvol on
+	ext_malloc_name=$(rpc_cmd bdev_malloc_create "$lvol_size" $MALLOC_BS)
+
+	# Make a deep copy of lvol over external bdev
+	deep_copy=$(rpc_cmd bdev_lvol_start_deep_copy "$lvol_uuid" "$ext_malloc_name")
+	operation_id=$(echo $deep_copy | jq -r '.operation_id')
+
+	# Check status of operation
+	retry=0
+	while [[ $retry -lt 10 ]]; do
+		status=$(rpc_cmd bdev_lvol_check_deep_copy $operation_id)
+		result=$(echo $status | jq -r '.state')
+		processed_clusters=$(echo $status | jq -r '.processed_clusters')
+		total_clusters=$(echo $status | jq -r '.total_clusters')
+
+		if [[ "$result" == "complete" ]]; then
+			[[ $processed_clusters == 4 ]]
+			[[ $total_clusters == 4 ]]
+			break
+		fi
+
+		retry=$((retry + 1))
+		sleep 1
+	done
+
+	[[ $retry -lt 10 ]]
+
+	# Create nbd devices of lvol and external bdev for comparison
+	nbd_start_disks "$DEFAULT_RPC_ADDR" "$lvol_uuid" /dev/nbd0
+	nbd_start_disks "$DEFAULT_RPC_ADDR" "$ext_malloc_name" /dev/nbd1
+
+	# Compare lvol and external bdev in first, second, and fourth cluster
+	cmp -n "$LVS_DEFAULT_CLUSTER_SIZE" /dev/nbd0 /dev/nbd1
+	cmp -n "$LVS_DEFAULT_CLUSTER_SIZE" /dev/nbd0 /dev/nbd1 "$LVS_DEFAULT_CLUSTER_SIZE" "$LVS_DEFAULT_CLUSTER_SIZE"
+	cmp -n "$LVS_DEFAULT_CLUSTER_SIZE" /dev/nbd0 /dev/nbd1 "$((LVS_DEFAULT_CLUSTER_SIZE * 3))" "$((LVS_DEFAULT_CLUSTER_SIZE * 3))"
+
+
+	# Check that third cluster of external bdev is zero filled
+	cmp -n "$LVS_DEFAULT_CLUSTER_SIZE" /dev/nbd1 /dev/zero "$((LVS_DEFAULT_CLUSTER_SIZE * 2))"
+
+	# Stop nbd devices
+	nbd_stop_disks "$DEFAULT_RPC_ADDR" /dev/nbd1
+	nbd_stop_disks "$DEFAULT_RPC_ADDR" /dev/nbd0
+
+	# Clean up
+	rpc_cmd bdev_malloc_delete "$ext_malloc_name"
+	rpc_cmd bdev_lvol_delete "$snapshot_uuid"
+	rpc_cmd bdev_lvol_delete "$lvol_uuid"
+	rpc_cmd bdev_lvol_delete_lvstore -u "$lvs_uuid"
+	rpc_cmd bdev_malloc_delete "$bs_malloc_name"
+	check_leftover_devices
+}
+
 $SPDK_BIN_DIR/spdk_tgt &
 spdk_pid=$!
 trap 'killprocess "$spdk_pid"; exit 1' SIGINT SIGTERM EXIT
@@ -175,6 +254,7 @@ modprobe nbd
 
 run_test "test_shallow_copy_compare" test_shallow_copy_compare
 run_test "test_range_shallow_copy_compare" test_range_shallow_copy_compare
+run_test "test_deep_copy_compare" test_deep_copy_compare
 
 trap - SIGINT SIGTERM EXIT
 killprocess $spdk_pid

--- a/test/unit/lib/bdev/vbdev_lvol.c/vbdev_lvol_ut.c
+++ b/test/unit/lib/bdev/vbdev_lvol.c/vbdev_lvol_ut.c
@@ -952,6 +952,23 @@ spdk_lvol_range_shallow_copy(struct spdk_lvol *lvol, uint64_t *clusters_indexes,
 	return 0;
 }
 
+int
+spdk_lvol_deep_copy(struct spdk_lvol *lvol, struct spdk_bs_dev *ext_dev,
+		    spdk_blob_deep_copy_status status_cb_fn, void *status_cb_arg,
+		    spdk_lvol_op_complete cb_fn, void *cb_arg)
+{
+	if (lvol == NULL) {
+		return -ENODEV;
+	}
+
+	if (ext_dev == NULL) {
+		return -ENODEV;
+	}
+
+	cb_fn(cb_arg, 0);
+	return 0;
+}
+
 void
 spdk_lvol_set_external_parent(struct spdk_lvol *lvol, const void *esnap_id, uint32_t id_len,
 			      spdk_lvol_op_complete cb_fn, void *cb_arg)
@@ -1011,6 +1028,12 @@ ut_init_bdev(char *bdev_name, const char *uuid_str)
 
 static void
 vbdev_lvol_shallow_copy_complete(void *cb_arg, int lvolerrno)
+{
+	g_lvolerrno = lvolerrno;
+}
+
+static void
+vbdev_lvol_deep_copy_complete(void *cb_arg, int lvolerrno)
 {
 	g_lvolerrno = lvolerrno;
 }
@@ -2342,6 +2365,59 @@ ut_lvol_range_shallow_copy(void)
 }
 
 static void
+ut_lvol_deep_copy(void)
+{
+	struct spdk_lvol_store *lvs;
+	int sz = 10;
+	int rc;
+
+	ut_init_bdev(DEFAULT_BDEV_NAME, DEFAULT_BDEV_UUID);
+
+	/* Lvol store is successfully created */
+	rc = vbdev_lvs_create(DEFAULT_BDEV_NAME, "lvs", 0, LVS_CLEAR_WITH_UNMAP, 0,
+			      lvol_store_op_with_handle_complete, NULL);
+	CU_ASSERT(rc == 0);
+	CU_ASSERT(g_lvserrno == 0);
+	SPDK_CU_ASSERT_FATAL(g_lvol_store != NULL);
+	CU_ASSERT(g_lvol_store->bs_dev != NULL);
+	lvs = g_lvol_store;
+
+	/* Successful lvol create */
+	g_lvolerrno = -1;
+	rc = vbdev_lvol_create(lvs, "lvol_sc", sz, false, LVOL_CLEAR_WITH_DEFAULT,
+			       vbdev_lvol_create_complete,
+			       NULL);
+	SPDK_CU_ASSERT_FATAL(rc == 0);
+	SPDK_CU_ASSERT_FATAL(g_lvol != NULL);
+	CU_ASSERT(g_lvolerrno == 0);
+
+	/* Deep copy error with NULL lvol */
+	rc = vbdev_lvol_deep_copy(NULL, "", NULL, NULL, vbdev_lvol_deep_copy_complete, NULL);
+	CU_ASSERT(rc == -EINVAL);
+
+	/* Deep copy error with NULL bdev name */
+	rc = vbdev_lvol_deep_copy(g_lvol, NULL, NULL, NULL, vbdev_lvol_deep_copy_complete, NULL);
+	CU_ASSERT(rc == -EINVAL);
+
+	/* Successful deep copy */
+	g_lvolerrno = -1;
+	lvol_already_opened = false;
+	rc = vbdev_lvol_deep_copy(g_lvol, DEFAULT_BDEV_NAME, NULL, NULL,
+				  vbdev_lvol_deep_copy_complete, NULL);
+	CU_ASSERT(rc == 0);
+	CU_ASSERT(g_lvolerrno == 0);
+
+	/* Successful lvol destroy */
+	vbdev_lvol_destroy(g_lvol, lvol_store_op_complete, NULL);
+	CU_ASSERT(g_lvol == NULL);
+
+	/* Destroy lvol store */
+	vbdev_lvs_destruct(lvs, lvol_store_op_complete, NULL);
+	CU_ASSERT(g_lvserrno == 0);
+	CU_ASSERT(g_lvol_store == NULL);
+}
+
+static void
 ut_lvol_set_external_parent(void)
 {
 	struct spdk_lvol_store lvs = { 0 };
@@ -2560,6 +2636,7 @@ main(int argc, char **argv)
 	CU_ADD_TEST(suite, ut_lvol_esnap_clone_bad_args);
 	CU_ADD_TEST(suite, ut_lvol_shallow_copy);
 	CU_ADD_TEST(suite, ut_lvol_range_shallow_copy);
+	CU_ADD_TEST(suite, ut_lvol_deep_copy);
 	CU_ADD_TEST(suite, ut_lvol_set_external_parent);
 	CU_ADD_TEST(suite, ut_lvol_quiesce);
 

--- a/test/unit/lib/blob/blob.c/blob_ut.c
+++ b/test/unit/lib/blob/blob.c/blob_ut.c
@@ -4759,8 +4759,9 @@ blob_thin_prov_rw(void)
 	if (g_use_extent_table) {
 		/* Add one more page for EXTENT_PAGE write */
 		expected_bytes += spdk_bs_get_page_size(bs);
-	}	
-	CU_ASSERT(((g_dev_write_bytes - write_bytes)-(g_dev_write_zeroes_bytes - write_zeroes_bytes)) == expected_bytes);
+	}
+	CU_ASSERT(((g_dev_write_bytes - write_bytes) - (g_dev_write_zeroes_bytes - write_zeroes_bytes)) ==
+		  expected_bytes);
 	CU_ASSERT(g_dev_read_bytes - read_bytes == 0);
 
 	spdk_blob_io_read(blob, channel, payload_read, 4, 10, blob_op_complete, NULL);
@@ -4871,7 +4872,8 @@ blob_thin_prov_write_count_io(void)
 			 */
 			expected_bytes = io_unit_size + 2 * spdk_bs_get_page_size(bs);
 		}
-		CU_ASSERT(((g_dev_write_bytes - write_bytes)-(g_dev_write_zeroes_bytes - write_zeroes_bytes)) == expected_bytes);
+		CU_ASSERT(((g_dev_write_bytes - write_bytes) - (g_dev_write_zeroes_bytes - write_zeroes_bytes)) ==
+			  expected_bytes);
 
 		/* The write should have synced the metadata already.  Do another sync here
 		 * just to confirm.
@@ -4905,7 +4907,8 @@ blob_thin_prov_write_count_io(void)
 		 * For extent table metadata, we should have written the I/O and the extent metadata page.
 		 */
 		expected_bytes = io_unit_size + spdk_bs_get_page_size(bs);
-		CU_ASSERT(((g_dev_write_bytes - write_bytes)-(g_dev_write_zeroes_bytes - write_zeroes_bytes)) == expected_bytes);
+		CU_ASSERT(((g_dev_write_bytes - write_bytes) - (g_dev_write_zeroes_bytes - write_zeroes_bytes)) ==
+			  expected_bytes);
 
 		/* Send unmap aligned to the whole cluster - should free it up */
 		g_bserrno = -1;
@@ -5261,7 +5264,8 @@ blob_thin_prov_rle(void)
 		/* Add one more page for EXTENT_PAGE write */
 		expected_bytes += spdk_bs_get_page_size(bs);
 	}
-	CU_ASSERT(((g_dev_write_bytes - write_bytes)-(g_dev_write_zeroes_bytes - write_zeroes_bytes)) == expected_bytes);
+	CU_ASSERT(((g_dev_write_bytes - write_bytes) - (g_dev_write_zeroes_bytes - write_zeroes_bytes)) ==
+		  expected_bytes);
 	CU_ASSERT(g_dev_read_bytes - read_bytes == 0);
 
 	spdk_blob_io_read(blob, channel, payload_read, io_unit, 10, blob_op_complete, NULL);

--- a/test/unit/lib/blob/blob.c/blob_ut.c
+++ b/test/unit/lib/blob/blob.c/blob_ut.c
@@ -33,6 +33,7 @@ uint64_t g_ctx = 1729;
 bool g_use_extent_table = false;
 uint64_t g_copied_clusters_count = 0;
 uint64_t g_unmapped_clusters_count = 0;
+uint64_t g_processed_clusters_count = 0;
 
 struct spdk_bs_super_block_ver1 {
 	uint8_t		signature[8];
@@ -211,6 +212,13 @@ blob_shallow_copy_status_cb(uint64_t copied_clusters, uint64_t unmapped_clusters
 	g_copied_clusters_count = copied_clusters;
 	g_unmapped_clusters_count = unmapped_clusters;
 }
+
+static void
+blob_deep_copy_status_cb(uint64_t processed_clusters, void *cb_arg)
+{
+	g_processed_clusters_count = processed_clusters;
+}
+
 
 static bool
 blob_snapshot_checksum_stop_cb(void *cb_arg)
@@ -10215,6 +10223,171 @@ blob_range_shallow_copy(void)
 }
 
 static void
+blob_deep_copy(void)
+{
+	struct spdk_blob_store *bs = g_bs;
+	struct spdk_blob_opts blob_opts;
+	struct spdk_blob *blob;
+	spdk_blob_id blobid;
+	uint64_t num_clusters = 4;
+	struct spdk_bs_dev *ext_dev;
+	struct spdk_bs_dev_cb_args ext_args;
+	struct spdk_io_channel *bdev_ch, *blob_ch;
+	uint8_t buf1[DEV_BUFFER_BLOCKLEN];
+	uint8_t buf2[DEV_BUFFER_BLOCKLEN];
+	uint64_t io_units_per_cluster;
+	uint64_t offset;
+	int rc;
+
+	blob_ch = spdk_bs_alloc_io_channel(bs);
+	SPDK_CU_ASSERT_FATAL(blob_ch != NULL);
+
+	/* Set blob dimension and as thin provisioned */
+	ut_spdk_blob_opts_init(&blob_opts);
+	blob_opts.thin_provision = true;
+	blob_opts.num_clusters = num_clusters;
+
+	/* Create a blob */
+	blob = ut_blob_create_and_open(bs, &blob_opts);
+	SPDK_CU_ASSERT_FATAL(blob != NULL);
+	blobid = spdk_blob_get_id(blob);
+	io_units_per_cluster = bs_io_units_per_cluster(blob);
+
+	/* Write on cluster 2 and 4 of blob */
+	for (offset = io_units_per_cluster; offset < 2 * io_units_per_cluster; offset++) {
+		memset(buf1, offset, DEV_BUFFER_BLOCKLEN);
+		spdk_blob_io_write(blob, blob_ch, buf1, offset, 1, blob_op_complete, NULL);
+		poll_threads();
+		CU_ASSERT(g_bserrno == 0);
+	}
+	for (offset = 3 * io_units_per_cluster; offset < 4 * io_units_per_cluster; offset++) {
+		memset(buf1, offset, DEV_BUFFER_BLOCKLEN);
+		spdk_blob_io_write(blob, blob_ch, buf1, offset, 1, blob_op_complete, NULL);
+		poll_threads();
+		CU_ASSERT(g_bserrno == 0);
+	}
+	CU_ASSERT(spdk_blob_get_num_allocated_clusters(blob) == 2);
+
+	/* Make a snapshot over blob */
+	spdk_bs_create_snapshot(bs, blobid, NULL, blob_op_with_id_complete, NULL);
+	poll_threads();
+	CU_ASSERT(g_bserrno == 0);
+	CU_ASSERT(spdk_blob_get_num_allocated_clusters(blob) == 0);
+
+	/* Write on cluster 1 of blob */
+	for (offset = 0; offset < io_units_per_cluster; offset++) {
+		memset(buf1, offset, DEV_BUFFER_BLOCKLEN);
+		spdk_blob_io_write(blob, blob_ch, buf1, offset, 1, blob_op_complete, NULL);
+		poll_threads();
+		CU_ASSERT(g_bserrno == 0);
+	}
+	CU_ASSERT(spdk_blob_get_num_allocated_clusters(blob) == 1);
+
+	/* Deep copy with a not read only blob */
+	ext_dev = init_ext_dev(num_clusters * 1024 * 1024, DEV_BUFFER_BLOCKLEN);
+	rc = spdk_bs_blob_deep_copy(bs, blob_ch, blobid, ext_dev,
+				    blob_deep_copy_status_cb, NULL,
+				    blob_op_complete, NULL);
+	CU_ASSERT(rc == 0);
+	poll_threads();
+	CU_ASSERT(g_bserrno == -EPERM);
+	ext_dev->destroy(ext_dev);
+
+	/* Set blob read only */
+	spdk_blob_set_read_only(blob);
+	spdk_blob_sync_md(blob, blob_op_complete, NULL);
+	poll_threads();
+	CU_ASSERT(g_bserrno == 0);
+
+	/* Deep copy over a spdk_bs_dev with incorrect size */
+	ext_dev = init_ext_dev(1, DEV_BUFFER_BLOCKLEN);
+	rc = spdk_bs_blob_deep_copy(bs, blob_ch, blobid, ext_dev,
+				    blob_deep_copy_status_cb, NULL,
+				    blob_op_complete, NULL);
+	CU_ASSERT(rc == 0);
+	poll_threads();
+	CU_ASSERT(g_bserrno == -EINVAL);
+	ext_dev->destroy(ext_dev);
+
+	/* Deep copy over a spdk_bs_dev with incorrect block len */
+	ext_dev = init_ext_dev(num_clusters * 1024 * 1024, DEV_BUFFER_BLOCKLEN * 2);
+	rc = spdk_bs_blob_deep_copy(bs, blob_ch, blobid, ext_dev,
+				    blob_deep_copy_status_cb, NULL,
+				    blob_op_complete, NULL);
+	CU_ASSERT(rc == 0);
+	poll_threads();
+	CU_ASSERT(g_bserrno == -EINVAL);
+	ext_dev->destroy(ext_dev);
+
+	/* Initialize ext_dev for the successuful deep copy */
+	ext_dev = init_ext_dev(num_clusters * 1024 * 1024, DEV_BUFFER_BLOCKLEN);
+	bdev_ch = ext_dev->create_channel(ext_dev);
+	SPDK_CU_ASSERT_FATAL(bdev_ch != NULL);
+	ext_args.cb_fn = bs_dev_io_complete_cb;
+	for (offset = 0; offset < 4 * io_units_per_cluster; offset++) {
+		memset(buf2, 0xff, DEV_BUFFER_BLOCKLEN);
+		ext_dev->write(ext_dev, bdev_ch, buf2, offset, 1, &ext_args);
+		poll_threads();
+		CU_ASSERT(g_bserrno == 0);
+	}
+
+	/* Correct deep copy of blob over bdev */
+	rc = spdk_bs_blob_deep_copy(bs, blob_ch, blobid, ext_dev,
+				    blob_deep_copy_status_cb, NULL,
+				    blob_op_complete, NULL);
+	CU_ASSERT(rc == 0);
+	poll_thread_times(0, 1);
+	CU_ASSERT(g_bserrno == 0);
+	CU_ASSERT(g_processed_clusters_count == 1);
+	poll_thread_times(0, 1);
+	CU_ASSERT(g_bserrno == 0);
+	CU_ASSERT(g_processed_clusters_count == 2);
+	poll_thread_times(0, 1);
+	CU_ASSERT(g_bserrno == 0);
+	CU_ASSERT(g_processed_clusters_count == 4);
+
+
+	/* Read from bdev */
+	/* Only cluster 1, 2, and 4 must be filled */
+	/* Cluster 3 should not have been touched */
+	for (offset = 0; offset < io_units_per_cluster; offset++) {
+		memset(buf1, offset, DEV_BUFFER_BLOCKLEN);
+		ext_dev->read(ext_dev, bdev_ch, buf2, offset, 1, &ext_args);
+		poll_threads();
+		CU_ASSERT(g_bserrno == 0);
+		CU_ASSERT(memcmp(buf1, buf2, DEV_BUFFER_BLOCKLEN) == 0);
+	}
+	for (offset = io_units_per_cluster; offset < 2 * io_units_per_cluster; offset++) {
+		memset(buf1, offset, DEV_BUFFER_BLOCKLEN);
+		ext_dev->read(ext_dev, bdev_ch, buf2, offset, 1, &ext_args);
+		poll_threads();
+		CU_ASSERT(g_bserrno == 0);
+		CU_ASSERT(memcmp(buf1, buf2, DEV_BUFFER_BLOCKLEN) == 0);
+	}
+	for (offset = 2 * io_units_per_cluster; offset < 3 * io_units_per_cluster; offset++) {
+		memset(buf1, 0xff, DEV_BUFFER_BLOCKLEN);
+		ext_dev->read(ext_dev, bdev_ch, buf2, offset, 1, &ext_args);
+		poll_threads();
+		CU_ASSERT(g_bserrno == 0);
+		CU_ASSERT(memcmp(buf1, buf2, DEV_BUFFER_BLOCKLEN) == 0);
+	}
+	for (offset = 3 * io_units_per_cluster; offset < 4 * io_units_per_cluster; offset++) {
+		memset(buf1, offset, DEV_BUFFER_BLOCKLEN);
+		ext_dev->read(ext_dev, bdev_ch, buf2, offset, 1, &ext_args);
+		poll_threads();
+		CU_ASSERT(g_bserrno == 0);
+		CU_ASSERT(memcmp(buf1, buf2, DEV_BUFFER_BLOCKLEN) == 0);
+	}
+
+	/* Clean up */
+	ext_dev->destroy_channel(ext_dev, bdev_ch);
+	ext_dev->destroy(ext_dev);
+	spdk_bs_free_io_channel(blob_ch);
+	ut_blob_close_and_delete(bs, blob);
+	poll_threads();
+}
+
+static void
 blob_set_parent(void)
 {
 	struct spdk_blob_store *bs = g_bs;
@@ -11087,6 +11260,7 @@ main(int argc, char **argv)
 		CU_ADD_TEST(suite_bs, blob_clone_resize);
 		CU_ADD_TEST(suite, blob_esnap_clone_resize);
 		CU_ADD_TEST(suite_bs, blob_shallow_copy);
+		CU_ADD_TEST(suite_bs, blob_deep_copy);
 		CU_ADD_TEST(suite_bs, blob_range_shallow_copy);
 		CU_ADD_TEST(suite_esnap_bs, blob_set_parent);
 		CU_ADD_TEST(suite_esnap_bs, blob_set_external_parent);

--- a/test/unit/lib/lvol/lvol.c/lvol_ut.c
+++ b/test/unit/lib/lvol/lvol.c/lvol_ut.c
@@ -287,6 +287,16 @@ spdk_bs_blob_range_shallow_copy(struct spdk_blob_store *bs, struct spdk_io_chann
 	return 0;
 }
 
+int
+spdk_bs_blob_deep_copy(struct spdk_blob_store *bs, struct spdk_io_channel *channel,
+		       spdk_blob_id blobid, struct spdk_bs_dev *ext_dev,
+		       spdk_blob_deep_copy_status status_cb_fn, void *status_cb_arg,
+		       spdk_blob_op_complete cb_fn, void *cb_arg)
+{
+	cb_fn(cb_arg, 0);
+	return 0;
+}
+
 bool
 spdk_blob_is_snapshot(struct spdk_blob *blob)
 {
@@ -3679,6 +3689,66 @@ lvol_range_shallow_copy(void)
 }
 
 static void
+lvol_deep_copy(void)
+{
+	struct lvol_ut_bs_dev bs_dev;
+	struct spdk_lvs_opts opts;
+	struct spdk_bs_dev ext_dev;
+	int rc = 0;
+
+	init_dev(&bs_dev);
+
+	ext_dev.blocklen = DEV_BUFFER_BLOCKLEN;
+	ext_dev.blockcnt = BS_CLUSTER_SIZE / DEV_BUFFER_BLOCKLEN;
+
+	spdk_lvs_opts_init(&opts);
+	snprintf(opts.name, sizeof(opts.name), "lvs");
+
+	g_lvserrno = -1;
+	rc = spdk_lvs_init(&bs_dev.bs_dev, &opts, lvol_store_op_with_handle_complete, NULL);
+	CU_ASSERT(rc == 0);
+	CU_ASSERT(g_lvserrno == 0);
+	SPDK_CU_ASSERT_FATAL(g_lvol_store != NULL);
+
+	spdk_lvol_create(g_lvol_store, "lvol", BS_CLUSTER_SIZE, false, LVOL_CLEAR_WITH_DEFAULT,
+			 lvol_op_with_handle_complete, NULL);
+	CU_ASSERT(g_lvserrno == 0);
+	SPDK_CU_ASSERT_FATAL(g_lvol != NULL);
+
+	/* Successful deep copy */
+	g_blob_read_only = true;
+	rc = spdk_lvol_deep_copy(g_lvol, &ext_dev, NULL, NULL, op_complete, NULL);
+	CU_ASSERT(rc == 0);
+	CU_ASSERT(g_lvserrno == 0);
+
+	/* Deep copy with null lvol */
+	rc = spdk_lvol_deep_copy(NULL, &ext_dev, NULL, NULL, op_complete, NULL);
+	CU_ASSERT(rc == -EINVAL);
+
+	/* Deep copy with null ext_dev */
+	rc = spdk_lvol_shallow_copy(g_lvol, NULL, NULL, NULL, op_complete, NULL);
+	CU_ASSERT(rc == -EINVAL);
+
+	spdk_lvol_close(g_lvol, op_complete, NULL);
+	CU_ASSERT(g_lvserrno == 0);
+	spdk_lvol_destroy(g_lvol, op_complete, NULL);
+	CU_ASSERT(g_lvserrno == 0);
+
+	g_lvserrno = -1;
+	rc = spdk_lvs_unload(g_lvol_store, op_complete, NULL);
+	CU_ASSERT(rc == 0);
+	CU_ASSERT(g_lvserrno == 0);
+	g_lvol_store = NULL;
+
+	free_dev(&bs_dev);
+
+	/* Make sure that all references to the io_channel was closed after
+	 * deep copy call
+	 */
+	CU_ASSERT(g_io_channel == NULL);
+}
+
+static void
 lvol_set_parent(void)
 {
 	struct lvol_ut_bs_dev bs1_dev;
@@ -4021,6 +4091,7 @@ main(int argc, char **argv)
 	CU_ADD_TEST(suite, lvol_esnap_hotplug);
 	CU_ADD_TEST(suite, lvol_get_by);
 	CU_ADD_TEST(suite, lvol_shallow_copy);
+	CU_ADD_TEST(suite, lvol_deep_copy);
 	CU_ADD_TEST(suite, lvol_range_shallow_copy);
 	CU_ADD_TEST(suite, lvol_set_parent);
 	CU_ADD_TEST(suite, lvol_set_external_parent);


### PR DESCRIPTION
1. `bdev_lvol_start_deep_copy`: Start a deep copy of a lvol over a given bdev
2. `bdev_lvol_check_deep_copy`: Get deep copy status

longhorn/longhorn#7794
