### PR TITLE
lib/nvmf: limit number of NVMe-oF registrants when updating PTPL info

### DIFF
--- a/lib/nvmf/subsystem.c
+++ b/lib/nvmf/subsystem.c
@@ -2907,9 +2907,14 @@ nvmf_ns_update_reservation_info(struct spdk_nvmf_ns *ns)
 	}
 
 	TAILQ_FOREACH_SAFE(reg, &ns->registrants, link, tmp) {
-		spdk_uuid_fmt_lower(info.registrants[i].host_uuid, sizeof(info.registrants[i].host_uuid),
-				    &reg->hostid);
-		info.registrants[i++].rkey = reg->rkey;
+		if (i < SPDK_NVMF_MAX_NUM_REGISTRANTS) {
+			spdk_uuid_fmt_lower(info.registrants[i].host_uuid, sizeof(info.registrants[i].host_uuid),
+					    &reg->hostid);
+			info.registrants[i++].rkey = reg->rkey;
+		} else {
+			SPDK_ERRLOG("More registrants that can fit into reservation info, truncating\n");
+			break;
+		}
 	}
 
 	info.num_regs = i;

--- a/test/unit/lib/nvmf/subsystem.c/subsystem_ut.c
+++ b/test/unit/lib/nvmf/subsystem.c/subsystem_ut.c
@@ -2218,6 +2218,39 @@ test_nvmf_reservation_custom_ops(void)
 	ut_reservation_deinit();
 }
 
+static void
+test_nvmf_ns_reservation_add_max_registrants(void)
+{
+	struct spdk_nvmf_ns_reservation_ops ops = {
+		.is_ptpl_capable = ut_is_ptpl_capable,
+		.update = ut_update_reservation,
+		.load = ut_load_reservation,
+	};
+	spdk_nvmf_set_custom_ns_reservation_ops(&ops);
+	ut_reservation_init();
+
+	struct spdk_nvmf_reservation_info info = {};
+	int rc;
+
+	/* Register 1 past the max */
+	uint32_t i = 0;
+	for (i = 0; i < SPDK_NVMF_MAX_NUM_REGISTRANTS + 1; i++) {
+		spdk_uuid_generate(&g_ctrlr1_A.hostid);
+		rc = nvmf_ns_reservation_add_registrant(&g_ns, &g_ctrlr1_A, 0xa11 + i);
+		CU_ASSERT(rc == 0);
+	}
+	/* Update the reservation info */
+	rc = nvmf_ns_update_reservation_info(&g_ns);
+	CU_ASSERT(rc == 0);
+	/* Validate that info is capped at max */
+	rc = nvmf_ns_reservation_load(&g_ns, &info);
+	CU_ASSERT(rc == 0);
+	CU_ASSERT_EQUAL(info.num_regs, SPDK_NVMF_MAX_NUM_REGISTRANTS);
+	/* Clear should return max + 1 */
+	uint32_t cleared = nvmf_ns_reservation_clear_all_registrants(&g_ns);
+	CU_ASSERT_EQUAL(cleared, SPDK_NVMF_MAX_NUM_REGISTRANTS + 1);
+}
+
 int
 main(int argc, char **argv)
 {
@@ -2252,6 +2285,7 @@ main(int argc, char **argv)
 	CU_ADD_TEST(suite, test_nvmf_ns_reservation_restore);
 	CU_ADD_TEST(suite, test_nvmf_subsystem_state_change);
 	CU_ADD_TEST(suite, test_nvmf_reservation_custom_ops);
+	CU_ADD_TEST(suite, test_nvmf_ns_reservation_add_max_registrants);
 
 	allocate_threads(1);
 	set_thread(0);


### PR DESCRIPTION
Limit the number of NVMe-oF registrants that are kept when using PTPL (Persist through power loss).

Change-Id: I5207652b4a6e7313b3b4dbee212aa2be692d8b59

Reported-by: Joel Cunningham <joel.cunningham@oracle.com>

Reviewed-on: https://review.spdk.io/c/spdk/spdk/+/26777
Tested-by: SPDK Automated Test System <spdkbot@gmail.com>
Reviewed-by: Konrad Sztyber <ksztyber@nvidia.com>
Reviewed-by: Jacek Kalwas <jacek.kalwas@nutanix.com>

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/11970

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
