### PR TITLE
fix(blob): defer spdk_blob_close in shallow/deep copy and snapshot checksum I/O completion callbacks

### DIFF
--- a/lib/blob/blobstore.c
+++ b/lib/blob/blobstore.c
@@ -8637,6 +8637,14 @@ bs_snapshot_checksum_cleanup_finish(void *cb_arg, int bserrno)
 }
 
 static void
+bs_snapshot_checksum_close_blob(void *cb_arg)
+{
+	struct snapshot_checksum_ctx *ctx = cb_arg;
+
+	spdk_blob_close(ctx->blob, bs_snapshot_checksum_cleanup_finish, ctx);
+}
+
+static void
 bs_snapshot_checksum_md_synchronized(void *cb_arg, int bserrno)
 {
 	struct snapshot_checksum_ctx *ctx = cb_arg;
@@ -8682,7 +8690,7 @@ bs_snapshot_checksum_blob_read_cpl(void *cb_arg, int bserrno)
 		ctx->bserrno = bserrno;
 		_blob->locked_operation_in_progress = false;
 		bs_snapshot_free_clusters_checksums(_blob);
-		spdk_blob_close(_blob, bs_snapshot_checksum_cleanup_finish, ctx);
+		spdk_thread_send_msg(spdk_get_thread(), bs_snapshot_checksum_close_blob, ctx);
 		return;
 	}
 
@@ -8708,7 +8716,7 @@ bs_snapshot_checksum_cluster_find_next(void *cb_arg)
 		ctx->bserrno = -EINTR;
 		_blob->locked_operation_in_progress = false;
 		bs_snapshot_free_clusters_checksums(_blob);
-		spdk_blob_close(_blob, bs_snapshot_checksum_cleanup_finish, ctx);
+		spdk_thread_send_msg(spdk_get_thread(), bs_snapshot_checksum_close_blob, ctx);
 		return;
 	}
 

--- a/lib/blob/blobstore.c
+++ b/lib/blob/blobstore.c
@@ -7586,6 +7586,14 @@ bs_shallow_copy_cleanup_finish(void *cb_arg, int bserrno)
 }
 
 static void
+bs_shallow_copy_close_blob(void *cb_arg)
+{
+	struct shallow_copy_ctx *ctx = cb_arg;
+
+	spdk_blob_close(ctx->blob, bs_shallow_copy_cleanup_finish, ctx);
+}
+
+static void
 bs_shallow_copy_bdev_unmap_cpl(struct spdk_io_channel *channel, void *cb_arg, int bserrno)
 {
 	struct shallow_copy_ctx *ctx = cb_arg;
@@ -7595,7 +7603,7 @@ bs_shallow_copy_bdev_unmap_cpl(struct spdk_io_channel *channel, void *cb_arg, in
 		SPDK_ERRLOG("blob 0x%" PRIx64 " shallow copy, ext dev unmap error %d\n", ctx->blob->id, bserrno);
 		ctx->bserrno = bserrno;
 		_blob->locked_operation_in_progress = false;
-		spdk_blob_close(_blob, bs_shallow_copy_cleanup_finish, ctx);
+		spdk_thread_send_msg(spdk_get_thread(), bs_shallow_copy_close_blob, ctx);
 		return;
 	}
 
@@ -7618,7 +7626,7 @@ bs_shallow_copy_bdev_write_cpl(struct spdk_io_channel *channel, void *cb_arg, in
 		SPDK_ERRLOG("blob 0x%" PRIx64 " shallow copy, ext dev write error %d\n", ctx->blob->id, bserrno);
 		ctx->bserrno = bserrno;
 		_blob->locked_operation_in_progress = false;
-		spdk_blob_close(_blob, bs_shallow_copy_cleanup_finish, ctx);
+		spdk_thread_send_msg(spdk_get_thread(), bs_shallow_copy_close_blob, ctx);
 		return;
 	}
 
@@ -7647,7 +7655,7 @@ bs_shallow_copy_blob_read_cpl(void *cb_arg, int bserrno)
 		SPDK_ERRLOG("blob 0x%" PRIx64 " shallow copy, blob read error %d\n", ctx->blob->id, bserrno);
 		ctx->bserrno = bserrno;
 		_blob->locked_operation_in_progress = false;
-		spdk_blob_close(_blob, bs_shallow_copy_cleanup_finish, ctx);
+		spdk_thread_send_msg(spdk_get_thread(), bs_shallow_copy_close_blob, ctx);
 		return;
 	}
 
@@ -7688,7 +7696,7 @@ bs_range_shallow_copy_cluster_handle_next(void *cb_arg)
 		}
 	} else {
 		_blob->locked_operation_in_progress = false;
-		spdk_blob_close(_blob, bs_shallow_copy_cleanup_finish, ctx);
+		spdk_thread_send_msg(spdk_get_thread(), bs_shallow_copy_close_blob, ctx);
 	}
 }
 
@@ -7714,7 +7722,9 @@ bs_shallow_copy_cluster_find_next(void *cb_arg)
 					      bs_shallow_copy_blob_read_cpl, ctx, SPDK_BLOB_READ);
 	} else {
 		_blob->locked_operation_in_progress = false;
-		spdk_blob_close(_blob, bs_shallow_copy_cleanup_finish, ctx);
+		SPDK_NOTICELOG("blob 0x%" PRIx64 " shallow copy, copied clusters: %" PRIu64 ", unmapped clusters: %" PRIu64 "\n",
+				   _blob->id, ctx->copied_clusters_count, ctx->unmapped_clusters_count);
+		spdk_thread_send_msg(spdk_get_thread(), bs_shallow_copy_close_blob, ctx);
 	}
 }
 
@@ -7954,6 +7964,14 @@ bs_deep_copy_cleanup_finish(void *cb_arg, int bserrno)
 }
 
 static void
+bs_deep_copy_close_blob(void *cb_arg)
+{
+	struct deep_copy_ctx *ctx = cb_arg;
+
+	spdk_blob_close(ctx->blob, bs_deep_copy_cleanup_finish, ctx);
+}
+
+static void
 bs_deep_copy_bdev_write_cpl(struct spdk_io_channel *channel, void *cb_arg, int bserrno)
 {
 	struct deep_copy_ctx *ctx = cb_arg;
@@ -7963,7 +7981,7 @@ bs_deep_copy_bdev_write_cpl(struct spdk_io_channel *channel, void *cb_arg, int b
 		SPDK_ERRLOG("blob 0x%" PRIx64 " deep copy, ext dev write error %d\n", ctx->blob->id, bserrno);
 		ctx->bserrno = bserrno;
 		_blob->locked_operation_in_progress = false;
-		spdk_blob_close(_blob, bs_deep_copy_cleanup_finish, ctx);
+		spdk_thread_send_msg(spdk_get_thread(), bs_deep_copy_close_blob, ctx);
 		return;
 	}
 
@@ -7987,7 +8005,7 @@ bs_deep_copy_blob_read_cpl(void *cb_arg, int bserrno)
 		SPDK_ERRLOG("blob 0x%" PRIx64 " deep copy, blob read error %d\n", ctx->blob->id, bserrno);
 		ctx->bserrno = bserrno;
 		_blob->locked_operation_in_progress = false;
-		spdk_blob_close(_blob, bs_deep_copy_cleanup_finish, ctx);
+		spdk_thread_send_msg(spdk_get_thread(), bs_deep_copy_close_blob, ctx);
 		return;
 	}
 
@@ -8049,7 +8067,9 @@ bs_deep_copy_cluster_find_next(void *cb_arg)
 			ctx->status_cb(_blob->active.num_clusters, ctx->status_cb_arg);
 		}
 		_blob->locked_operation_in_progress = false;
-		spdk_blob_close(_blob, bs_deep_copy_cleanup_finish, ctx);
+		SPDK_NOTICELOG("blob 0x%" PRIx64 " deep copy completed, total clusters: %" PRIu64 "\n",
+				   _blob->id, _blob->active.num_clusters);
+		spdk_thread_send_msg(spdk_get_thread(), bs_deep_copy_close_blob, ctx);
 	}
 }
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#10599

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
