### PR TITLE
fix: skip esnap device creation if lvol is NULL and potential NPE

### DIFF
--- a/module/bdev/lvol/vbdev_lvol.c
+++ b/module/bdev/lvol/vbdev_lvol.c
@@ -2181,8 +2181,8 @@ vbdev_lvol_esnap_dev_create(void *bs_ctx, void *blob_ctx, struct spdk_blob *blob
 	char			uuid_str[SPDK_UUID_STRING_LEN] = { 0 };
 
 	if (lvol == NULL) {
-		SPDK_ERRLOG("lvol is NULL\n");
-		return -EINVAL;
+		SPDK_NOTICELOG("Skip esnap device creation for NULL lvol\n");
+		return 0;
 	}
 
 	if (esnap_id == NULL) {

--- a/module/bdev/lvol/vbdev_lvol.c
+++ b/module/bdev/lvol/vbdev_lvol.c
@@ -2180,6 +2180,11 @@ vbdev_lvol_esnap_dev_create(void *bs_ctx, void *blob_ctx, struct spdk_blob *blob
 	int			rc;
 	char			uuid_str[SPDK_UUID_STRING_LEN] = { 0 };
 
+	if (lvol == NULL) {
+		SPDK_ERRLOG("lvol is NULL\n");
+		return -EINVAL;
+	}
+
 	if (esnap_id == NULL) {
 		SPDK_ERRLOG("lvol %s: NULL esnap ID\n", lvol->unique_id);
 		return -EINVAL;


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#7124

#### What this PR does / why we need it:

During spdk_bs_load() iteration, spdk_bs_open_blob() is called without
opts, resulting in a NULL esnap_ctx (blob_ctx). This means the lvol
pointer passed to vbdev_lvol_esnap_dev_create() is NULL.

Previously, this would cause a NULL pointer dereference when accessing
lvol->unique_id. The initial fix returned -EINVAL, but this caused
blob_load_esnap() to treat it as an error, preventing the esnap clone
lvol from being loaded.

Return 0 with bs_dev left as NULL to indicate that the consumer chose
not to open the external snapshot device. This aligns with the existing
contract in blob_load_esnap(), which explicitly handles NULL bs_dev as
a valid case (the esnap device will be set up later via hotplug).

#### Special notes for your reviewer:

#### Additional documentation or context
